### PR TITLE
fix: qt 5.14 compatibility issues

### DIFF
--- a/platformthemeplugin/qdeepintheme.cpp
+++ b/platformthemeplugin/qdeepintheme.cpp
@@ -557,7 +557,7 @@ static void onAutoScaleWindowChanged()
 static bool updateScaleLogcailDpi(const QPair<qreal, qreal> &dpi)
 {
     bool ok = dpi.first >= 0 && dpi.second >= 0;
-
+#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
     if (dpi.first > 0) {
         QHighDpiScaling::m_logicalDpi.first = dpi.first;
     } else if (qIsNull(dpi.first)) {
@@ -569,7 +569,9 @@ static bool updateScaleLogcailDpi(const QPair<qreal, qreal> &dpi)
     } else if (qIsNull(dpi.second)) {
         QHighDpiScaling::m_logicalDpi.second = qGuiApp->primaryScreen()->handle()->logicalDpi().second;
     }
-
+#else
+    QHighDpiScaling::m_usePixelDensity = false;
+#endif
     return ok;
 }
 


### PR DESCRIPTION
Without the fix qdeepin platformtheme failed to load:

```
Cannot load library /usr/lib/qt/plugins/platformthemes/libqdeepin.so: (/usr/lib/qt/plugins/platformthemes/libqdeepin.so: undefined symbol: _ZN15QHighDpiScaling12m_logicalDpiE)
```