### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-qt5integration.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-qt5integration.spec
+    - .packit.yaml
+
+upstream_package_name: qt5integration
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-qt5integration
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"0,/Version:/ s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-qt5integration.spec"

--- a/rpm/deepin-qt5integration.spec
+++ b/rpm/deepin-qt5integration.spec
@@ -1,0 +1,67 @@
+%global repo qt5integration
+
+Name:           deepin-qt5integration
+Version:        5.1.0.13
+Release:        1%{?dist}
+Summary:        Qt platform theme integration plugins for DDE
+# The entire source code is GPLv3+ except styles/ which is BSD,
+# styleplugins/dstyleplugin/dstyleanimation* which is LGPL
+License:        GPLv3+ and BSD and LGPLv2+
+URL:            https://github.com/linuxdeepin/qt5integration
+Source0:        %{url}/archive/%{version}/%{repo}-%{version}.tar.gz
+
+BuildRequires:  gcc-c++
+BuildRequires:  pkgconfig(atk)
+BuildRequires:  pkgconfig(dtkcore)
+BuildRequires:  pkgconfig(dtkwidget) >= 2.0.6
+BuildRequires:  pkgconfig(fontconfig)
+BuildRequires:  pkgconfig(freetype2)
+BuildRequires:  pkgconfig(gtk+-2.0)
+BuildRequires:  pkgconfig(glib-2.0)
+BuildRequires:  pkgconfig(gdk-pixbuf-2.0)
+BuildRequires:  pkgconfig(ice)
+BuildRequires:  pkgconfig(libinput)
+BuildRequires:  pkgconfig(libudev)
+BuildRequires:  pkgconfig(pango)
+BuildRequires:  pkgconfig(Qt5Core)
+BuildRequires:  pkgconfig(Qt5OpenGL)
+BuildRequires:  pkgconfig(Qt5Svg)
+BuildRequires:  pkgconfig(Qt5Xdg) >= 3.0.0
+BuildRequires:  pkgconfig(Qt5X11Extras)
+BuildRequires:  pkgconfig(x11)
+BuildRequires:  pkgconfig(xext)
+BuildRequires:  pkgconfig(xrender)
+BuildRequires:  pkgconfig(xcb)
+BuildRequires:  pkgconfig(mtdev)
+BuildRequires:  pkgconfig(Qt5Multimedia)
+BuildRequires:  pkgconfig(Qt5MultimediaWidgets)
+BuildRequires:  qt5-qtbase-common
+# for libQt5ThemeSupport.a
+BuildRequires:  qt5-qtbase-static
+BuildRequires:  qt5-qtbase-private-devel
+%{?_qt5:Requires: %{_qt5}%{?_isa} = %{_qt5_version}}
+Requires:       deepin-qt5dxcb-plugin%{?_isa}
+
+%description
+Multiple Qt plugins to provide better Qt5 integration for DDE is included.
+
+%prep
+%autosetup -p1 -n %{repo}-%{version}
+
+%build
+%qmake_qt5 PREFIX=%{_prefix}
+%make_build
+
+%install
+%make_install INSTALL_ROOT=%{buildroot}
+
+%files
+%doc README.md
+%license LICENSE
+%{_qt5_plugindir}/platformthemes/libqdeepin.so
+%{_qt5_plugindir}/iconengines/libdsvgicon.so
+%{_qt5_plugindir}/imageformats/libdsvg.so
+%{_qt5_plugindir}/iconengines/libdtkbuiltin.so
+%{_qt5_plugindir}/styles/libchameleon.so
+
+%changelog


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log: Initial packit setup
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>