### PR TITLE
chore: 菜单圆角跟随控制中心圆角变化

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -27,6 +27,7 @@
 #include <DPlatformWindowHandle>
 #include <DApplicationHelper>
 #include <DWindowManagerHelper>
+#include <DPlatformTheme>
 #include <DSlider>
 #include <DTabBar>
 #include <DSearchEdit>
@@ -4187,7 +4188,10 @@ void ChameleonStyle::polish(QWidget *w)
 
             if (DPlatformWindowHandle::isEnabledDXcb(w)) {
                 handle.setEnableBlurWindow(true);
-                handle.setWindowRadius(8);
+                // 最大圆角8, 18忒大了，原来默认是8
+                auto theme = DGuiApplicationHelper::instance()->applicationTheme();
+                int wradius = theme->windowRadius();
+                handle.setWindowRadius(qMax(0, qMin(wradius, 8)));
                 w->setAttribute(Qt::WA_TranslucentBackground);
 
                 connect(DWindowManagerHelper::instance(), SIGNAL(hasCompositeChanged()), w, SLOT(update()));


### PR DESCRIPTION
社区版窗口圆角可以改变，不应该给菜单固定大小的圆角
此处从主题中获取圆角大小，但是最大不超过8（和以前保持一致）

Log: 菜单圆角保持一直
Influence: 菜单圆角
Change-Id: Idc86c46e3eabff070e0a9d635ceee81c6bbf6bd3