### PR TITLE
chore: 没有设置 BASED_DTK_DIR 时不生成chooser相关的库

### DIFF
--- a/qt5integration.pro
+++ b/qt5integration.pro
@@ -1,11 +1,14 @@
 TEMPLATE = subdirs
 SUBDIRS += \
-    src \
     styleplugins\
     platformthemeplugin/qt5deepintheme-plugin.pro \
     iconengineplugins/iconengines.pro \
     imageformatplugins/imageformats.pro \
     tests
+
+!isEmpty(BASED_DTK_DIR) {
+    SUBDIRS += src
+}
 
 CONFIG(debug, debug|release) {
     SUBDIRS += styles


### PR DESCRIPTION
上游不需要 BASED_DTK_DIR 宏来生成chooser插件，避免上游生成两个包

Log:
Influence: none
Change-Id: I3d565ee9b1f28c1a88b969e5693072979455ac11