### PR TITLE
fix: wayland 菜单界面未做圆角处理

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -4166,7 +4166,7 @@ void ChameleonStyle::polish(QWidget *w)
         view->setItemDelegate(new QStyledItemDelegate);
     }
 
-    if (DApplication::isDXcbPlatform()) {
+    if (DApplication::isDXcbPlatform() || (qApp->platformName() == "dwayland" || qApp->property("_d_isDwayland").toBool())) {
         bool is_menu = qobject_cast<QMenu *>(w);
         bool is_tip = w->inherits("QTipLabel");
 


### PR DESCRIPTION
当设置menu圆角时候，增加wayland条件判断

Log: 修复工具栏二级菜单界面未做圆角处理问题
Bug: https://pms.uniontech.com/bug-view-101126.html
Influence: 二级菜单圆角