### PR TITLE
fix: 警告提示时，combobox输入框背景色无变化

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -2246,9 +2246,9 @@ bool ChameleonStyle::drawComboBox(QPainter *painter, const QStyleOptionComboBox 
         painter->setRenderHint(QPainter::Antialiasing);
 
         if (comboBox->editable)
-            painter->setBrush(getThemTypeColor(QColor(0, 0, 0, 255* 0.08),
-                                         QColor(255, 255, 255, 255 * 0.15)));
-         else
+            painter->setBrush(widget->testAttribute(Qt::WA_SetPalette) ?
+                              comboBox->palette.button() : getThemTypeColor(QColor(0, 0, 0, 255* 0.08), QColor(255, 255, 255, 255 * 0.15)));
+        else
             painter->setBrush(Qt::transparent);
 
         DDrawUtils::drawRoundedRect(painter, comboBoxCopy.rect, frameRadius, frameRadius,


### PR DESCRIPTION
绘制combobox时增加调色板变化判断。
调色板变化时，设置画刷为palette.button。

Log: 修复警告提示时，combobox输入框背景色无变化问题
Bug: https://pms.uniontech.com/bug-view-128179.html
Influence: 可编辑combobox样式