### PR TITLE
fix: combobox弹出菜单文字和图片重叠

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -2895,7 +2895,7 @@ bool ChameleonStyle::drawMenuItem(const QStyleOptionMenuItem *option, QPainter *
         int xpos = menuRect.x(); //1.只有文本  2.只有图片加文本  ，xpos为文本的起始坐标
 
         if (iconSize.width() > 0) {
-            xpos += realMargins + smallIconSize + frameRadius;
+            xpos += realMargins + smallIconSize + frameRadius + iconSize.width();
         } else {
             xpos += realMargins;
         }


### PR DESCRIPTION
combobox弹出菜单计算时未加上图片的宽度导致图片和文字重叠

Log:
Bug:
Influence: none
Change-Id: I05ebe21d0ce72250450884ce31005fb8a368f301