### PR TITLE
fix: 带图标的combobox文字过长未省略

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -2365,8 +2365,9 @@ bool ChameleonStyle::drawComboBoxLabel(QPainter *painter, const QStyleOptionComb
         const int contentLeftPadding = flat ? (contentsRect.width() - contentsWidth) / 2 : Metrics::ComboBox_ContentLeftMargin;
         iconRect = QRect(QPoint(contentsRect.left() + contentLeftPadding,
                                 contentsRect.top() + (contentsRect.height() - iconSize.height()) / 2), iconSize);
+        const int availableTextWidth = contentsRect.width() - contentLeftPadding - iconSize.width() - Metrics::Icon_Margins - downArrowRect.width();
         textRect = QRect(QPoint(iconRect.right() + Metrics::Icon_Margins + 1,
-                                contentsRect.top() + (contentsRect.height() - textSize.height()) / 2), textSize);
+                                contentsRect.top() + (contentsRect.height() - textSize.height()) / 2), QSize(availableTextWidth, textSize.height()));
     }
 
     // handle right to left


### PR DESCRIPTION
取得宽度是整个文字内容的宽度，
修改为可以绘制文字的区域宽度。

Log: 修复带图标combobox文字过长未省略问题
Bug: https://pms.uniontech.com/bug-view-135023.html
Influence: DCombobox显示