### PR TITLE
fix: 可编辑的combobox警告提示时没有警告背景色

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -2254,11 +2254,23 @@ bool ChameleonStyle::drawComboBox(QPainter *painter, const QStyleOptionComboBox 
         painter->setPen(Qt::NoPen);
         painter->setRenderHint(QPainter::Antialiasing);
 
-        if (comboBox->editable)
-            painter->setBrush(widget->testAttribute(Qt::WA_SetPalette) ?
-                              comboBox->palette.button() : getThemTypeColor(QColor(0, 0, 0, 255* 0.08), QColor(255, 255, 255, 255 * 0.15)));
-        else
+        if (comboBox->editable) {
+            if (widget->testAttribute(Qt::WA_SetPalette)) {
+                painter->setBrush(comboBox->palette.button());
+            } else {
+                const QComboBox *combobox = qobject_cast<const QComboBox *>(widget);
+                if (combobox && combobox->lineEdit()) {
+                    if (combobox->lineEdit()->testAttribute(Qt::WA_SetPalette)) {
+                        painter->setBrush(combobox->lineEdit()->palette().button());
+                    } else {
+                        painter->setBrush(getThemTypeColor(QColor(0, 0, 0, 255 * 0.08),
+                                                           QColor(255, 255, 255, 255 * 0.15)));
+                    }
+                }
+            }
+        } else {
             painter->setBrush(Qt::transparent);
+        }
 
         DDrawUtils::drawRoundedRect(painter, comboBoxCopy.rect, frameRadius, frameRadius,
                                     DDrawUtils::Corner::TopLeftCorner


### PR DESCRIPTION
combobox在可编辑状态下，背景色取lineEdit的调色板button的颜色

Log: 修复combobox警告提示时没有警告背景色问题
Bug: https://pms.uniontech.com/bug-view-128179.html
Influence: combobox背景色