### PR TITLE
chore: remove qt5widget5 depends from themeplugin

### DIFF
--- a/platformthemeplugin/qdeepinfiledialoghelper.h
+++ b/platformthemeplugin/qdeepinfiledialoghelper.h
@@ -24,7 +24,6 @@
 
 QT_BEGIN_NAMESPACE
 
-class QFileDialog;
 class ComDeepinFilemanagerFiledialogInterface;
 typedef ComDeepinFilemanagerFiledialogInterface DFileDialogHandle;
 class ComDeepinFilemanagerFiledialogmanagerInterface;
@@ -59,11 +58,10 @@ protected:
     void onApplicationStateChanged(Qt::ApplicationState state);
     void onWindowActiveChanged();
 private:
-    mutable QPointer<DFileDialogHandle> nativeDialog;
+    mutable QPointer<DFileDialogHandle> filedlgInterface;
     mutable QPointer<QWindow> auxiliaryWindow;
-    mutable QPointer<QFileDialog> qtDialog;
     QPointer<QWindow> activeWindow;
-    QPointer<QFileDialog> sourceDialog;
+    QPointer<QObject> sourceDialog;
     static DFileDialogManager *manager;
 
     void ensureDialog() const;

--- a/platformthemeplugin/qt5deepintheme-plugin.pro
+++ b/platformthemeplugin/qt5deepintheme-plugin.pro
@@ -6,7 +6,6 @@ isEmpty(DTK_VERSION) {
 QT       += dbus x11extras dtkgui$${DTK_VERSION}
 QT       += core-private gui-private
 greaterThan(QT_MAJOR_VERSION, 4) {
-  QT += widgets widgets-private
   # Qt >= 5.8
   greaterThan(QT_MAJOR_VERSION, 5)|greaterThan(QT_MINOR_VERSION, 7): QT += theme_support-private
   else: QT += platformsupport-private

--- a/src/platformthemes/platformthemechooser/platformthemechooser.pro
+++ b/src/platformthemes/platformthemechooser/platformthemechooser.pro
@@ -1,5 +1,5 @@
 greaterThan(QT_MAJOR_VERSION, 4) {
-  QT += widgets widgets-private
+  QT += gui-private
 }
 
 LIBS += -ldl


### PR DESCRIPTION
1. 主题插件移除qt5widget5的依赖(QT += widgets widgets-privat)
2. 重命名变量 nativedialog -> filedlgInterface

Log: remove depends
Influence: filedialog
Change-Id: Ie95a1b663524bddeb1c6777d510e642b24e9ee23