### PR TITLE
fix: 主窗口和子菜单窗口边框重叠显示

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -4024,7 +4024,7 @@ int ChameleonStyle::pixelMetric(QStyle::PixelMetric m, const QStyleOption *opt,
         //非特效效果则 menu border 为 1
         return DWindowManagerHelper::instance()->hasComposite() ? 0 : 1;
     case PM_SubMenuOverlap:
-        return -1;
+        return 0;
     case PM_ComboBoxFrameWidth: { //这是ComboBox VMargin
         const QStyleOptionComboBox *comboBoxOption(qstyleoption_cast< const QStyleOptionComboBox *>(opt));
         return comboBoxOption && comboBoxOption->editable ? Metrics::ComboBox_FrameWidth : Metrics::LineEdit_FrameWidth ;


### PR DESCRIPTION
修改为PM_SubMenuOverlap的pixelMetric返回0

Log: 修复主菜单和子菜单边框重叠显示问题
Bug: https://pms.uniontech.com/bug-view-134533.html
Influence: 主菜单和子菜单UI