### PR TITLE
chore: replace dde-qt5integration5.5

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,8 @@ Standards-Version: 3.9.8
 Package: dde-qt5integration
 Architecture: any
 Provides: libqt5deepintheme-plugin
-Conflicts: libqt5deepintheme-plugin
+Conflicts: libqt5deepintheme-plugin, dde-qt5integration5.5
+Replaces: dde-qt5integration5.5
 Depends: ${shlibs:Depends}, ${misc:Depends}, dde-qt5xcb-plugin, dde-qt5integration5
 Description: Qt platform theme integration plugin choosers for DDE
  Multiple Qt plugin choosers for DDE is included.


### PR DESCRIPTION
dde-qt5integration5.5 was deprecated

Log: 升级时卸载dde-qt5integration5.5
Bug: https://pms.uniontech.com/bug-view-138883.html
Influence: dtk5.5
Change-Id: I0e785380e0c6cfa957c7893d5b071a1b148e1929