### PR TITLE
fix: 减小菜单项图标和文本的距离

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -2918,7 +2918,7 @@ bool ChameleonStyle::drawMenuItem(const QStyleOptionMenuItem *option, QPainter *
         int xpos = menuRect.x(); //1.只有文本  2.只有图片加文本  ，xpos为文本的起始坐标
 
         if (iconSize.width() > 0) {
-            xpos += realMargins + smallIconSize + frameRadius + iconSize.width();
+            xpos += realMargins + frameRadius + iconSize.width();
         } else {
             xpos += realMargins;
         }
@@ -3913,7 +3913,7 @@ QSize ChameleonStyle::sizeFromContents(QStyle::ContentsType ct, const QStyleOpti
                 m_width += (textWidth + frameRadius);
 
             if (!menuItem->icon.isNull())
-                m_width += (smallIconSize + + frameRadius);
+                m_width += (smallIconSize + frameRadius);
 
             m_width += (smallIconSize + frameRadius);
             size.setWidth(m_width);


### PR DESCRIPTION
计算菜单项文本的位置时，
多加了smallIconSize距离。

Log: 菜单项图标和文本的距离减少smallIconSize
Bug: https://pms.uniontech.com/bug-view-140633.html
Influence: 弹出菜单
Change-Id: I4e0bdfda7f24833450a746cc117bc76bd6a00ad4