### PR TITLE
feat: configurable proxy icon engine

### DIFF
--- a/platformthemeplugin/qdeepintheme.cpp
+++ b/platformthemeplugin/qdeepintheme.cpp
@@ -506,9 +506,17 @@ static QIconEngine *createBuiltinIconEngine(const QString &iconName)
     return plugin ? plugin->create(iconName) : nullptr;
 }
 
+inline QString dgetenv(const char * varname, const QString & defaultValue) {
+    if (Q_UNLIKELY(qEnvironmentVariableIsSet(varname))) {
+        return qgetenv(varname);
+    }
+
+    return defaultValue;
+}
+
 static QIconEngine *createXdgProxyIconEngine(const QString &iconName)
 {
-    static QIconEnginePlugin *plugin = getIconEngineFactory(QStringLiteral("XdgIconProxyEngine"));
+    static QIconEnginePlugin *plugin = getIconEngineFactory(dgetenv("D_PROXY_ICON_ENGINE", QStringLiteral("XdgIconProxyEngine")));
 
     return plugin ? plugin->create(iconName) : nullptr;
 }


### PR DESCRIPTION
支持可配置所使用的代理 Qt 图标引擎

当前 qdeepintheme 所自动选用的是其附带的图标引擎，此图标引擎在部分（至少在 Arch Linux）平台存在一些渲染问题，例如无法正常渲染 SVG 1.2 Tiny 之外的图标（如现在发布时提供的 `deepin-image-viewer` 图标），或是包含 `ColorScheme-Text` 之外颜色定义的图标（如 KDE breeze-icon-theme 中的 folder 图标，使用了 `ColorScheme-Highlight`）。

![截图_选择区域_20220710163048](https://user-images.githubusercontent.com/10095765/178138447-823cc0c3-5c74-419c-8413-dbfdb1af47d7.png)

比较快捷的 workaround 即使 qdeepintheme 所创建的图标引擎可配置而非 hardcode 到指定图标引擎，此 PR 在现有的配置文件`~/.config/deepin/qt-theme.ini` 中，追加了一个配置项 `ProxyIconEngineName`，允许通过指定图标引擎的名称来使 deepin 主题使用给定的图标引擎。

当然上述问题也应当考虑在 deepin 所提供的图标引擎中进行修复。