### PR TITLE
fix: 可编辑的combobox没有背景色

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -2290,19 +2290,18 @@ bool ChameleonStyle::drawComboBox(QPainter *painter, const QStyleOptionComboBox 
         painter->setRenderHint(QPainter::Antialiasing);
 
         if (comboBox->editable) {
+            QBrush brush = getThemTypeColor(QColor(0, 0, 0, 255 * 0.08),
+                                            QColor(255, 255, 255, 255 * 0.15));
             if (widget->testAttribute(Qt::WA_SetPalette)) {
-                painter->setBrush(comboBox->palette.button());
-            } else {
-                const QComboBox *combobox = qobject_cast<const QComboBox *>(widget);
-                if (combobox && combobox->lineEdit()) {
-                    if (combobox->lineEdit()->testAttribute(Qt::WA_SetPalette)) {
-                        painter->setBrush(combobox->lineEdit()->palette().button());
-                    } else {
-                        painter->setBrush(getThemTypeColor(QColor(0, 0, 0, 255 * 0.08),
-                                                           QColor(255, 255, 255, 255 * 0.15)));
+                brush = comboBox->palette.button();
+            } else if (const QComboBox *combobox = qobject_cast<const QComboBox *>(widget)) {
+                if (auto lineEdit = combobox->lineEdit()) {
+                    if (lineEdit->testAttribute(Qt::WA_SetPalette)) {
+                        brush = lineEdit->palette().button();
                     }
                 }
             }
+            painter->setBrush(brush);
         } else {
             painter->setBrush(Qt::transparent);
         }


### PR DESCRIPTION
可编辑combobox设置个默认背景色，
如果有设置警告，则以警告对象的调色板button为背景色。

Log: 修复可编辑的combobox没有背景色问题
Bug: https://pms.uniontech.com/bug-view-146359.html
Influence: combobox
Change-Id: I74883c52a4c237280683f487830b5ec5ddd20e38