### PR TITLE
fix: iconengine 缩放后绘制 pixmap 问题

### DIFF
--- a/iconengineplugins/builtinengine/dbuiltiniconengine.cpp
+++ b/iconengineplugins/builtinengine/dbuiltiniconengine.cpp
@@ -217,12 +217,11 @@ void DBuiltinIconEngine::paint(QPainter *painter, const QRect &rect,
 {
     ensureLoaded();
 
-    QSize pixmapSize = rect.size();
-    qreal scale = 1;
-    if (painter->device())
-        scale = painter->device()->devicePixelRatioF();
+    qreal scale = 1.0;
+    if (qApp->testAttribute(Qt::AA_UseHighDpiPixmaps))
+        scale = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
 
-    pixmapSize *= scale;
+    QSize pixmapSize = rect.size() * scale;
 
     QIconLoaderEngineEntry *entry = QIconLoaderEngine::entryForSize(m_info, pixmapSize);
     if (!entry)

--- a/iconengineplugins/svgiconengine/qsvgiconengine.cpp
+++ b/iconengineplugins/svgiconengine/qsvgiconengine.cpp
@@ -365,10 +365,15 @@ void QSvgIconEngine::addFile(const QString &fileName, const QSize &,
 void QSvgIconEngine::paint(QPainter *painter, const QRect &rect,
                            QIcon::Mode mode, QIcon::State state)
 {
-    QSize pixmapSize = rect.size();
-    if (painter->device())
-        pixmapSize *= painter->device()->devicePixelRatioF();
-    painter->drawPixmap(rect, pixmap(pixmapSize, mode, state));
+    qreal ratio = 1.0;
+    if (qApp->testAttribute(Qt::AA_UseHighDpiPixmaps))
+        ratio = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+
+    QSize pixmapSize = rect.size() * ratio;
+    QPixmap pix = pixmap(pixmapSize, mode, state);
+
+    pix.setDevicePixelRatio(ratio);
+    painter->drawPixmap(rect, pix);
 }
 
 QString QSvgIconEngine::key() const

--- a/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.cpp
+++ b/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.cpp
@@ -202,11 +202,16 @@ void XdgIconProxyEngine::paint(QPainter *painter, const QRect &rect, QIcon::Mode
         DEEPIN_QT_THEME::colorScheme.setLocalData(mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name());
     }
 
-    const QPixmap pix = pixmap(rect.size(), mode, state);
+    qreal ratio = 1.0;
+    if (qApp->testAttribute(Qt::AA_UseHighDpiPixmaps))
+        ratio = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+
+    QPixmap pix = pixmap(rect.size() * ratio, mode, state);
 
     if (pix.isNull())
         return;
 
+    pix.setDevicePixelRatio(ratio);
     painter->drawPixmap(rect, pix);
 }
 


### PR DESCRIPTION
较大的图标（如1024x1024）的 pixmap 在缩放（如2）时出现图标模糊
因为绘制时获取的 pixmap 的 size 未乘以缩放值

Bug: https://pms.uniontech.com/bug-view-154115.html
Log: 图标模糊
Change-Id: I650fbb3886464067ba8a5086d9e5ff2373dfabd7