### PR TITLE
fix crash && icon intercepted

### DIFF
--- a/iconengineplugins/dciiconengine/dciiconengine.cpp
+++ b/iconengineplugins/dciiconengine/dciiconengine.cpp
@@ -71,7 +71,7 @@ QSize DDciIconEngine::actualSize(const QSize &size, QIcon::Mode mode, QIcon::Sta
 {
     Q_UNUSED(state);
     int s = m_dciIcon.actualSize(qMin(size.width(), size.height()), dciTheme(), dciMode(mode));
-    return QSize(s, s);
+    return QSize(s, s).boundedTo(size);
 }
 
 QPixmap DDciIconEngine::pixmap(const QSize &size, QIcon::Mode mode, QIcon::State state)

--- a/iconengineplugins/dciiconengine/dciiconengine.cpp
+++ b/iconengineplugins/dciiconengine/dciiconengine.cpp
@@ -29,9 +29,10 @@ static inline DDciIconPalette dciPalettle(QPaintDevice *paintDevice = nullptr)
     QPalette pa;
     if (!paintDevice || paintDevice->devType() != QInternal::Widget) {
         pa = qApp->palette();
-    } else {
-        QObject *obj = reinterpret_cast<QObject *>(paintDevice);
+    } else if (QObject *obj = dynamic_cast<QObject *>(paintDevice)) {
         pa = qvariant_cast<QPalette>(obj->property("palette"));
+    } else {
+        pa = qApp->palette();
     }
 
     return DDciIconPalette(pa.windowText().color(), pa.window().color(),


### PR DESCRIPTION
use dynamic_cast instead of reinterpret_cast

Log: crash when use dciiconengine
Bug: none
Influecen: none