### PR TITLE
fix: dci icon not changed

### DIFF
--- a/iconengineplugins/dciiconengine/dciiconengine.h
+++ b/iconengineplugins/dciiconengine/dciiconengine.h
@@ -29,9 +29,11 @@ public:
     QString iconName() const override;
 private:
     void virtual_hook(int id, void *data) override;
+    void ensureIconTheme();
 
     DDciIconEngine(const DDciIconEngine &other);
     QString m_iconName;
+    QString m_iconThemeName;
     DDciIcon m_dciIcon;
 };
 


### PR DESCRIPTION
icon not changed whene switch dci icon theme
check icon theme name in dciiconengine

Log: fix dci icon not changed
Influence: dci icon theme
Change-Id: Ie8adbf6d31abff9152c7f1a381b23834a59a3802