### PR TITLE
fix: qicon::isNull always return false

### DIFF
--- a/iconengineplugins/diconproxyengine/diconproxyengine.cpp
+++ b/iconengineplugins/diconproxyengine/diconproxyengine.cpp
@@ -179,7 +179,15 @@ void DIconProxyEngine::virtual_hook(int id, void *data)
         return;
     }
 
-    QIconEngine::virtual_hook(id, data);
+    switch (id) {
+    case QIconEngine::IsNullHook:
+        {
+            *reinterpret_cast<bool*>(data) = true;
+        }
+        break;
+    default:
+        QIconEngine::virtual_hook(id, data);
+    }
 }
 
 void DIconProxyEngine::ensureEngine()

--- a/platformthemeplugin/qdeepintheme.cpp
+++ b/platformthemeplugin/qdeepintheme.cpp
@@ -517,7 +517,7 @@ QIconEngine *QDeepinTheme::createIconEngine(const QString &iconName) const
     return XdgIconEngineCreator::create(iconName);
 #else
 
-    return nullptr;
+    return QGenericUnixTheme::createIconEngine(iconName);
 #endif
 }
 


### PR DESCRIPTION
if proxy iconengine is null, virtual_hook return
QIconEngine::virtual_hook, by default QIconEngine::isNull return false

Log: none
Influence: qicon.isNull reuturn false
Change-Id: I0b656b3e759006056a12bd74d5dacdff44880f80