### PR TITLE
feat: basic support for ColorScheme-Highlight

### DIFF
--- a/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.cpp
+++ b/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.cpp
@@ -29,11 +29,14 @@
 
 #if XDG_ICON_VERSION_MAR >= 3
 namespace DEEPIN_QT_THEME {
-QThreadStorage<QString> colorScheme;
+QThreadStorage<QPair<QString, QString>> colorScheme; // <text, highlight>
 void (*setFollowColorScheme)(bool);
 bool (*followColorScheme)();
 } // namespace DEEPIN_QT_THEME
 #endif
+
+static const QString STYLE = QStringLiteral(".ColorScheme-Text, .ColorScheme-NeutralText{color:%1;}\
+\n.ColorScheme-Highlight{color:%2;}");
 
 QT_BEGIN_NAMESPACE
 XdgIconProxyEngine::XdgIconProxyEngine(XdgIconLoaderEngine *proxy)
@@ -66,13 +69,13 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
 
     lastMode = mode;
     quint64 cache_key = entryCacheKey(color_entry, mode, state);
-    const QString &cache_color_scheme = entryToColorScheme.value(cache_key);
+    const QPair<QString, QString> &cache_color_scheme = entryToColorScheme.value(cache_key);
 
     // 当size为1时表示此svg文件不需要处理ColorScheme标签
-    if (cache_color_scheme.size() == 1)
+    if (cache_color_scheme.first.size() == 1)
         return color_entry->pixmap(size, mode, state);
 
-    const QString &color_scheme = DEEPIN_QT_THEME::colorScheme.localData();
+    const QPair<QString, QString> &color_scheme = DEEPIN_QT_THEME::colorScheme.localData();
     QPixmap pm = color_scheme == cache_color_scheme ? color_entry->svgIcon.pixmap(size, mode, state) : QPixmap();
     // Note: not checking the QIcon::isNull(), because in Qt5.10 the isNull() is not reliable
     // for svg icons desierialized from stream (see https://codereview.qt-project.org/#/c/216086/)
@@ -86,7 +89,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
         if (device.open(QIODevice::ReadOnly)) {
             // Note: indexes are assembled as in qtsvg (QSvgIconEnginePrivate::hashKey())
             QPair<int, QString> style_sheet;
-            style_sheet = qMakePair((mode << 4) | state, QStringLiteral(".ColorScheme-Text{color:%1;}").arg(color_scheme));
+            style_sheet = qMakePair((mode << 4) | state, STYLE.arg(color_scheme.first, color_scheme.second));
             QSharedPointer<QXmlStreamWriter> writer(new QXmlStreamWriter {&svg_buffers[style_sheet.first]});
 
             QXmlStreamReader xmlReader(&device);
@@ -114,7 +117,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
 
         if (invalidBuffers) {
             // 此svg图标无ColorScheme标签时不应该再下面的操作，且应该记录下来，避免后续再处理svg文件内容
-            entryToColorScheme[cache_key] = QStringLiteral("#");
+            entryToColorScheme[cache_key] = qMakePair(QStringLiteral("#"), QString());
             return color_entry->pixmap(size, mode, state);
         }
 
@@ -128,7 +131,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
         str.setVersion(QDataStream::Qt_4_4);
         QHash<int, QString> filenames;
         filenames[0] = color_entry->filename; // Note: filenames are ignored in the QSvgIconEngine::read()
-        filenames[-1] = color_scheme; // 在dsvg插件中会为svg图标做缓存，此处是为其添加额外的缓存文件key标识，避免不同color的svg图标会命中同一个缓存文件
+        filenames[-1] = color_scheme.first + color_scheme.second; // 在dsvg插件中会为svg图标做缓存，此处是为其添加额外的缓存文件key标识，避免不同color的svg图标会命中同一个缓存文件
         str << QStringLiteral("svg") << filenames << static_cast<int>(0) /*isCompressed*/ << svg_buffers << static_cast<int>(0) /*hasAddedPimaps*/;
 
         QDataStream str_read {&icon_arr, QIODevice::ReadOnly};
@@ -152,7 +155,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
 QPixmap XdgIconProxyEngine::pixmapByEntry(QIconLoaderEngineEntry *entry, const QSize &size, QIcon::Mode mode, QIcon::State state)
 {
     if (!XdgIcon::followColorScheme()) {
-        DEEPIN_QT_THEME::colorScheme.setLocalData(QString());
+        DEEPIN_QT_THEME::colorScheme.setLocalData(qMakePair(QString(), QString()));
 
         return entry->pixmap(size, mode, state);
     }
@@ -161,9 +164,12 @@ QPixmap XdgIconProxyEngine::pixmapByEntry(QIconLoaderEngineEntry *entry, const Q
     char *type_name = abi::__cxa_demangle(typeid(*entry).name(), 0, 0, 0);
 
     if (type_name == QByteArrayLiteral("ScalableFollowsColorEntry")) {
-        if (DEEPIN_QT_THEME::colorScheme.localData().isEmpty()) {
+        if (DEEPIN_QT_THEME::colorScheme.localData().first.isEmpty()) {
             const QPalette &pal = qApp->palette();
-            DEEPIN_QT_THEME::colorScheme.setLocalData(mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name());
+            DEEPIN_QT_THEME::colorScheme.setLocalData(qMakePair(
+                mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name(),
+                pal.highlight().color().name()
+            ));
         }
 
         pixmap = followColorPixmap(static_cast<ScalableEntry *>(entry), size, mode, state);
@@ -172,7 +178,7 @@ QPixmap XdgIconProxyEngine::pixmapByEntry(QIconLoaderEngineEntry *entry, const Q
     }
 
     free(type_name);
-    DEEPIN_QT_THEME::colorScheme.setLocalData(QString());
+    DEEPIN_QT_THEME::colorScheme.setLocalData(qMakePair(QString(), QString()));
 
     return pixmap;
 }
@@ -181,9 +187,12 @@ void XdgIconProxyEngine::paint(QPainter *painter, const QRect &rect, QIcon::Mode
 {
     if (painter->device()->devType() == QInternal::Widget
         && XdgIcon::followColorScheme()
-        && DEEPIN_QT_THEME::colorScheme.localData().isEmpty()) {
+        && DEEPIN_QT_THEME::colorScheme.localData().first.isEmpty()) {
         const QPalette &pal = qvariant_cast<QPalette>(dynamic_cast<QObject *>(painter->device())->property("palette"));
-        DEEPIN_QT_THEME::colorScheme.setLocalData(mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name());
+        DEEPIN_QT_THEME::colorScheme.setLocalData(qMakePair(
+            mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name(),
+            pal.highlight().color().name()
+        ));
     }
 
     qreal ratio = 1.0;
@@ -206,7 +215,7 @@ QPixmap XdgIconProxyEngine::pixmap(const QSize &size, QIcon::Mode mode, QIcon::S
     QIconLoaderEngineEntry *entry = engine->entryForSize(size);
 
     if (!entry) {
-        DEEPIN_QT_THEME::colorScheme.setLocalData(QString());
+        DEEPIN_QT_THEME::colorScheme.setLocalData(qMakePair(QString(), QString()));
 
         return QPixmap();
     }
@@ -264,7 +273,7 @@ void XdgIconProxyEngine::virtual_hook(int id, void *data)
         qGuiApp->setAttribute(Qt::AA_UseHighDpiPixmaps, false);
         arg.pixmap = entry ? pixmapByEntry(entry, arg.size, arg.mode, arg.state) : QPixmap();
         qGuiApp->setAttribute(Qt::AA_UseHighDpiPixmaps, useHighDpiPixmap);
-        DEEPIN_QT_THEME::colorScheme.setLocalData(QString());
+        DEEPIN_QT_THEME::colorScheme.setLocalData(qMakePair(QString(), QString()));
 
         return;
     }

--- a/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.cpp
+++ b/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.cpp
@@ -29,7 +29,7 @@
 
 #if XDG_ICON_VERSION_MAR >= 3
 namespace DEEPIN_QT_THEME {
-QThreadStorage<QPair<QString, QString>> colorScheme; // <text, highlight>
+QThreadStorage<PALETTE_MAP> colorScheme; // <type, color>
 void (*setFollowColorScheme)(bool);
 bool (*followColorScheme)();
 } // namespace DEEPIN_QT_THEME
@@ -69,13 +69,13 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
 
     lastMode = mode;
     quint64 cache_key = entryCacheKey(color_entry, mode, state);
-    const QPair<QString, QString> &cache_color_scheme = entryToColorScheme.value(cache_key);
+    const DEEPIN_QT_THEME::PALETTE_MAP &cache_color_scheme = entryToColorScheme.value(cache_key);
 
     // 当size为1时表示此svg文件不需要处理ColorScheme标签
-    if (cache_color_scheme.first.size() == 1)
+    if (!cache_color_scheme.isEmpty() && cache_color_scheme[DEEPIN_QT_THEME::Text].size() == 1)
         return color_entry->pixmap(size, mode, state);
 
-    const QPair<QString, QString> &color_scheme = DEEPIN_QT_THEME::colorScheme.localData();
+    const DEEPIN_QT_THEME::PALETTE_MAP &color_scheme = DEEPIN_QT_THEME::colorScheme.localData();
     QPixmap pm = color_scheme == cache_color_scheme ? color_entry->svgIcon.pixmap(size, mode, state) : QPixmap();
     // Note: not checking the QIcon::isNull(), because in Qt5.10 the isNull() is not reliable
     // for svg icons desierialized from stream (see https://codereview.qt-project.org/#/c/216086/)
@@ -89,7 +89,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
         if (device.open(QIODevice::ReadOnly)) {
             // Note: indexes are assembled as in qtsvg (QSvgIconEnginePrivate::hashKey())
             QPair<int, QString> style_sheet;
-            style_sheet = qMakePair((mode << 4) | state, STYLE.arg(color_scheme.first, color_scheme.second));
+            style_sheet = qMakePair((mode << 4) | state, STYLE.arg(color_scheme[DEEPIN_QT_THEME::Text], color_scheme[DEEPIN_QT_THEME::Highlight]));
             QSharedPointer<QXmlStreamWriter> writer(new QXmlStreamWriter {&svg_buffers[style_sheet.first]});
 
             QXmlStreamReader xmlReader(&device);
@@ -117,7 +117,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
 
         if (invalidBuffers) {
             // 此svg图标无ColorScheme标签时不应该再下面的操作，且应该记录下来，避免后续再处理svg文件内容
-            entryToColorScheme[cache_key] = qMakePair(QStringLiteral("#"), QString());
+            entryToColorScheme[cache_key] = DEEPIN_QT_THEME::PALETTE_MAP({ {DEEPIN_QT_THEME::Text, "#"} });
             return color_entry->pixmap(size, mode, state);
         }
 
@@ -131,7 +131,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
         str.setVersion(QDataStream::Qt_4_4);
         QHash<int, QString> filenames;
         filenames[0] = color_entry->filename; // Note: filenames are ignored in the QSvgIconEngine::read()
-        filenames[-1] = color_scheme.first + color_scheme.second; // 在dsvg插件中会为svg图标做缓存，此处是为其添加额外的缓存文件key标识，避免不同color的svg图标会命中同一个缓存文件
+        filenames[-1] = color_scheme[DEEPIN_QT_THEME::Text] + color_scheme[DEEPIN_QT_THEME::Highlight]; // 在dsvg插件中会为svg图标做缓存，此处是为其添加额外的缓存文件key标识，避免不同color的svg图标会命中同一个缓存文件
         str << QStringLiteral("svg") << filenames << static_cast<int>(0) /*isCompressed*/ << svg_buffers << static_cast<int>(0) /*hasAddedPimaps*/;
 
         QDataStream str_read {&icon_arr, QIODevice::ReadOnly};
@@ -155,7 +155,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
 QPixmap XdgIconProxyEngine::pixmapByEntry(QIconLoaderEngineEntry *entry, const QSize &size, QIcon::Mode mode, QIcon::State state)
 {
     if (!XdgIcon::followColorScheme()) {
-        DEEPIN_QT_THEME::colorScheme.setLocalData(qMakePair(QString(), QString()));
+        DEEPIN_QT_THEME::colorScheme.setLocalData(DEEPIN_QT_THEME::PALETTE_MAP());
 
         return entry->pixmap(size, mode, state);
     }
@@ -164,12 +164,12 @@ QPixmap XdgIconProxyEngine::pixmapByEntry(QIconLoaderEngineEntry *entry, const Q
     char *type_name = abi::__cxa_demangle(typeid(*entry).name(), 0, 0, 0);
 
     if (type_name == QByteArrayLiteral("ScalableFollowsColorEntry")) {
-        if (DEEPIN_QT_THEME::colorScheme.localData().first.isEmpty()) {
+        if (DEEPIN_QT_THEME::colorScheme.localData().isEmpty()) {
             const QPalette &pal = qApp->palette();
-            DEEPIN_QT_THEME::colorScheme.setLocalData(qMakePair(
-                mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name(),
-                pal.highlight().color().name()
-            ));
+            DEEPIN_QT_THEME::colorScheme.setLocalData(DEEPIN_QT_THEME::PALETTE_MAP({
+                { DEEPIN_QT_THEME::Text, mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name() },
+                { DEEPIN_QT_THEME::Highlight, pal.highlight().color().name() }
+            }));
         }
 
         pixmap = followColorPixmap(static_cast<ScalableEntry *>(entry), size, mode, state);
@@ -178,7 +178,7 @@ QPixmap XdgIconProxyEngine::pixmapByEntry(QIconLoaderEngineEntry *entry, const Q
     }
 
     free(type_name);
-    DEEPIN_QT_THEME::colorScheme.setLocalData(qMakePair(QString(), QString()));
+    DEEPIN_QT_THEME::colorScheme.setLocalData(DEEPIN_QT_THEME::PALETTE_MAP());
 
     return pixmap;
 }
@@ -187,12 +187,12 @@ void XdgIconProxyEngine::paint(QPainter *painter, const QRect &rect, QIcon::Mode
 {
     if (painter->device()->devType() == QInternal::Widget
         && XdgIcon::followColorScheme()
-        && DEEPIN_QT_THEME::colorScheme.localData().first.isEmpty()) {
+        && DEEPIN_QT_THEME::colorScheme.localData().isEmpty()) {
         const QPalette &pal = qvariant_cast<QPalette>(dynamic_cast<QObject *>(painter->device())->property("palette"));
-        DEEPIN_QT_THEME::colorScheme.setLocalData(qMakePair(
-            mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name(),
-            pal.highlight().color().name()
-        ));
+        DEEPIN_QT_THEME::colorScheme.setLocalData(DEEPIN_QT_THEME::PALETTE_MAP({
+            { DEEPIN_QT_THEME::Text, mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name() },
+            { DEEPIN_QT_THEME::Highlight, pal.highlight().color().name() }
+        }));
     }
 
     qreal ratio = 1.0;
@@ -215,7 +215,7 @@ QPixmap XdgIconProxyEngine::pixmap(const QSize &size, QIcon::Mode mode, QIcon::S
     QIconLoaderEngineEntry *entry = engine->entryForSize(size);
 
     if (!entry) {
-        DEEPIN_QT_THEME::colorScheme.setLocalData(qMakePair(QString(), QString()));
+        DEEPIN_QT_THEME::colorScheme.setLocalData(DEEPIN_QT_THEME::PALETTE_MAP());
 
         return QPixmap();
     }
@@ -273,7 +273,7 @@ void XdgIconProxyEngine::virtual_hook(int id, void *data)
         qGuiApp->setAttribute(Qt::AA_UseHighDpiPixmaps, false);
         arg.pixmap = entry ? pixmapByEntry(entry, arg.size, arg.mode, arg.state) : QPixmap();
         qGuiApp->setAttribute(Qt::AA_UseHighDpiPixmaps, useHighDpiPixmap);
-        DEEPIN_QT_THEME::colorScheme.setLocalData(qMakePair(QString(), QString()));
+        DEEPIN_QT_THEME::colorScheme.setLocalData(DEEPIN_QT_THEME::PALETTE_MAP());
 
         return;
     }

--- a/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.h
+++ b/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.h
@@ -16,6 +16,15 @@
 #include "xdgiconenginecreator.h"
 #endif
 
+namespace DEEPIN_QT_THEME {
+enum PaletteType {
+    Text,
+    Background,
+    Highlight,
+};
+typedef QMap<PaletteType, QString> PALETTE_MAP;
+};
+
 class ScalableEntry;
 class QIconLoaderEngineEntry;
 QT_BEGIN_NAMESPACE
@@ -44,7 +53,7 @@ public:
 
 private:
     XdgIconLoaderEngine *engine;
-    QHash<quint64, QPair<QString, QString>> entryToColorScheme;
+    QHash<quint64, DEEPIN_QT_THEME::PALETTE_MAP> entryToColorScheme;
     QIcon::Mode lastMode;
 };
 #endif

--- a/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.h
+++ b/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.h
@@ -44,7 +44,7 @@ public:
 
 private:
     XdgIconLoaderEngine *engine;
-    QHash<quint64, QString> entryToColorScheme;
+    QHash<quint64, QPair<QString, QString>> entryToColorScheme;
     QIcon::Mode lastMode;
 };
 #endif


### PR DESCRIPTION
对 ColorScheme-Highlight 非常初步的支持，尽管仍未支持 ColorScheme-Background。

此 patch 可解决 breeze 主题下，文件夹图标显示为黑色的问题。

测试方式：

1. 构建插件
2. 在较新的环境下，安装并切换默认主题到 breeze（deepin v20 可能不够新，建议使用 Arch，另，下述涉及的文件对应到[这个](https://github.com/KDE/breeze-icons/blob/master/icons/places/64/folder.svg)）
3. 获取并构建 https://github.com/BLumia/qt-icon-engine-tool （方便起见提供此工具）
4. 清空图标缓存（缓存位于 `~/.cache/deepin/icons`）
5. 使用 `QT_PLUGIN_PATH=/path/to/qt5integration/bin/plugins/` 启动上面构建得到的 `iconenginelist` 程序，并在下拉中选择 “DIconProxyEngine”
6. 观察效果，颜色非黑色即正常

![图片](https://user-images.githubusercontent.com/10095765/211785743-60882cad-6437-414b-aac5-b2c1e17eeb86.png)


此 patch 已知问题：

1. 切换当前主题色时不会清除缓存，所以会看到首次生成缓存时的图标。
