### PR TITLE
fix: local eventloop won't after manually close

### DIFF
--- a/platformthemeplugin/qdeepinfiledialoghelper.cpp
+++ b/platformthemeplugin/qdeepinfiledialoghelper.cpp
@@ -198,6 +198,7 @@ void QDeepinFileDialogHelper::exec()
     QEventLoop loop;
     connect(this, SIGNAL(accept()), &loop, SLOT(quit()));
     connect(this, SIGNAL(reject()), &loop, SLOT(quit()));
+    connect(this, SIGNAL(destroyed(QObject*)), &loop, SLOT(quit()));
     loop.exec();
 }
 


### PR DESCRIPTION
Invoking QFileDialog::close() will not quit local eventloop started by
QDeepinFileDialogHelper::exec(). Connect destroyed signal to quit slot of
local eventloop to fix this. Notice that user should destroy QFileDialog
to quit local eventloop.

Log: fix eventloop quit error
Bug: https://pms.uniontech.com/bug-view-183603.html