### PR TITLE
fix: file-manager is crashed when loading xdgiconproxyengine

### DIFF
--- a/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.cpp
+++ b/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.cpp
@@ -28,11 +28,9 @@
 #endif
 
 #if XDG_ICON_VERSION_MAR >= 3
-namespace DEEPIN_QT_THEME {
-QThreadStorage<PALETTE_MAP> colorScheme; // <type, color>
-void (*setFollowColorScheme)(bool);
-bool (*followColorScheme)();
-} // namespace DEEPIN_QT_THEME
+namespace DEEPIN_XDG_THEME {
+static QThreadStorage<PALETTE_MAP> colorScheme; // <type, color>
+};
 #endif
 
 static const QString STYLE = QStringLiteral(".ColorScheme-Text, .ColorScheme-NeutralText{color:%1;}\
@@ -69,13 +67,13 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
 
     lastMode = mode;
     quint64 cache_key = entryCacheKey(color_entry, mode, state);
-    const DEEPIN_QT_THEME::PALETTE_MAP &cache_color_scheme = entryToColorScheme.value(cache_key);
+    const DEEPIN_XDG_THEME::PALETTE_MAP &cache_color_scheme = entryToColorScheme.value(cache_key);
 
     // 当size为1时表示此svg文件不需要处理ColorScheme标签
-    if (!cache_color_scheme.isEmpty() && cache_color_scheme[DEEPIN_QT_THEME::Text].size() == 1)
+    if (!cache_color_scheme.isEmpty() && cache_color_scheme[DEEPIN_XDG_THEME::Text].size() == 1)
         return color_entry->pixmap(size, mode, state);
 
-    const DEEPIN_QT_THEME::PALETTE_MAP &color_scheme = DEEPIN_QT_THEME::colorScheme.localData();
+    const DEEPIN_XDG_THEME::PALETTE_MAP &color_scheme = DEEPIN_XDG_THEME::colorScheme.localData();
     QPixmap pm = color_scheme == cache_color_scheme ? color_entry->svgIcon.pixmap(size, mode, state) : QPixmap();
     // Note: not checking the QIcon::isNull(), because in Qt5.10 the isNull() is not reliable
     // for svg icons desierialized from stream (see https://codereview.qt-project.org/#/c/216086/)
@@ -89,7 +87,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
         if (device.open(QIODevice::ReadOnly)) {
             // Note: indexes are assembled as in qtsvg (QSvgIconEnginePrivate::hashKey())
             QPair<int, QString> style_sheet;
-            style_sheet = qMakePair((mode << 4) | state, STYLE.arg(color_scheme[DEEPIN_QT_THEME::Text], color_scheme[DEEPIN_QT_THEME::Highlight]));
+            style_sheet = qMakePair((mode << 4) | state, STYLE.arg(color_scheme[DEEPIN_XDG_THEME::Text], color_scheme[DEEPIN_XDG_THEME::Highlight]));
             QSharedPointer<QXmlStreamWriter> writer(new QXmlStreamWriter {&svg_buffers[style_sheet.first]});
 
             QXmlStreamReader xmlReader(&device);
@@ -117,7 +115,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
 
         if (invalidBuffers) {
             // 此svg图标无ColorScheme标签时不应该再下面的操作，且应该记录下来，避免后续再处理svg文件内容
-            entryToColorScheme[cache_key] = DEEPIN_QT_THEME::PALETTE_MAP({ {DEEPIN_QT_THEME::Text, "#"} });
+            entryToColorScheme[cache_key] = DEEPIN_XDG_THEME::PALETTE_MAP({ {DEEPIN_XDG_THEME::Text, "#"} });
             return color_entry->pixmap(size, mode, state);
         }
 
@@ -131,7 +129,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
         str.setVersion(QDataStream::Qt_4_4);
         QHash<int, QString> filenames;
         filenames[0] = color_entry->filename; // Note: filenames are ignored in the QSvgIconEngine::read()
-        filenames[-1] = color_scheme[DEEPIN_QT_THEME::Text] + color_scheme[DEEPIN_QT_THEME::Highlight]; // 在dsvg插件中会为svg图标做缓存，此处是为其添加额外的缓存文件key标识，避免不同color的svg图标会命中同一个缓存文件
+        filenames[-1] = color_scheme[DEEPIN_XDG_THEME::Text] + color_scheme[DEEPIN_XDG_THEME::Highlight]; // 在dsvg插件中会为svg图标做缓存，此处是为其添加额外的缓存文件key标识，避免不同color的svg图标会命中同一个缓存文件
         str << QStringLiteral("svg") << filenames << static_cast<int>(0) /*isCompressed*/ << svg_buffers << static_cast<int>(0) /*hasAddedPimaps*/;
 
         QDataStream str_read {&icon_arr, QIODevice::ReadOnly};
@@ -155,7 +153,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
 QPixmap XdgIconProxyEngine::pixmapByEntry(QIconLoaderEngineEntry *entry, const QSize &size, QIcon::Mode mode, QIcon::State state)
 {
     if (!XdgIcon::followColorScheme()) {
-        DEEPIN_QT_THEME::colorScheme.setLocalData(DEEPIN_QT_THEME::PALETTE_MAP());
+        DEEPIN_XDG_THEME::colorScheme.setLocalData(DEEPIN_XDG_THEME::PALETTE_MAP());
 
         return entry->pixmap(size, mode, state);
     }
@@ -164,11 +162,11 @@ QPixmap XdgIconProxyEngine::pixmapByEntry(QIconLoaderEngineEntry *entry, const Q
     char *type_name = abi::__cxa_demangle(typeid(*entry).name(), 0, 0, 0);
 
     if (type_name == QByteArrayLiteral("ScalableFollowsColorEntry")) {
-        if (DEEPIN_QT_THEME::colorScheme.localData().isEmpty()) {
+        if (DEEPIN_XDG_THEME::colorScheme.localData().isEmpty()) {
             const QPalette &pal = qApp->palette();
-            DEEPIN_QT_THEME::colorScheme.setLocalData(DEEPIN_QT_THEME::PALETTE_MAP({
-                { DEEPIN_QT_THEME::Text, mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name() },
-                { DEEPIN_QT_THEME::Highlight, pal.highlight().color().name() }
+            DEEPIN_XDG_THEME::colorScheme.setLocalData(DEEPIN_XDG_THEME::PALETTE_MAP({
+                { DEEPIN_XDG_THEME::Text, mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name() },
+                { DEEPIN_XDG_THEME::Highlight, pal.highlight().color().name() }
             }));
         }
 
@@ -178,7 +176,7 @@ QPixmap XdgIconProxyEngine::pixmapByEntry(QIconLoaderEngineEntry *entry, const Q
     }
 
     free(type_name);
-    DEEPIN_QT_THEME::colorScheme.setLocalData(DEEPIN_QT_THEME::PALETTE_MAP());
+    DEEPIN_XDG_THEME::colorScheme.setLocalData(DEEPIN_XDG_THEME::PALETTE_MAP());
 
     return pixmap;
 }
@@ -187,11 +185,11 @@ void XdgIconProxyEngine::paint(QPainter *painter, const QRect &rect, QIcon::Mode
 {
     if (painter->device()->devType() == QInternal::Widget
         && XdgIcon::followColorScheme()
-        && DEEPIN_QT_THEME::colorScheme.localData().isEmpty()) {
+        && DEEPIN_XDG_THEME::colorScheme.localData().isEmpty()) {
         const QPalette &pal = qvariant_cast<QPalette>(dynamic_cast<QObject *>(painter->device())->property("palette"));
-        DEEPIN_QT_THEME::colorScheme.setLocalData(DEEPIN_QT_THEME::PALETTE_MAP({
-            { DEEPIN_QT_THEME::Text, mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name() },
-            { DEEPIN_QT_THEME::Highlight, pal.highlight().color().name() }
+        DEEPIN_XDG_THEME::colorScheme.setLocalData(DEEPIN_XDG_THEME::PALETTE_MAP({
+            { DEEPIN_XDG_THEME::Text, mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name() },
+            { DEEPIN_XDG_THEME::Highlight, pal.highlight().color().name() }
         }));
     }
 
@@ -215,7 +213,7 @@ QPixmap XdgIconProxyEngine::pixmap(const QSize &size, QIcon::Mode mode, QIcon::S
     QIconLoaderEngineEntry *entry = engine->entryForSize(size);
 
     if (!entry) {
-        DEEPIN_QT_THEME::colorScheme.setLocalData(DEEPIN_QT_THEME::PALETTE_MAP());
+        DEEPIN_XDG_THEME::colorScheme.setLocalData(DEEPIN_XDG_THEME::PALETTE_MAP());
 
         return QPixmap();
     }
@@ -273,7 +271,7 @@ void XdgIconProxyEngine::virtual_hook(int id, void *data)
         qGuiApp->setAttribute(Qt::AA_UseHighDpiPixmaps, false);
         arg.pixmap = entry ? pixmapByEntry(entry, arg.size, arg.mode, arg.state) : QPixmap();
         qGuiApp->setAttribute(Qt::AA_UseHighDpiPixmaps, useHighDpiPixmap);
-        DEEPIN_QT_THEME::colorScheme.setLocalData(DEEPIN_QT_THEME::PALETTE_MAP());
+        DEEPIN_XDG_THEME::colorScheme.setLocalData(DEEPIN_XDG_THEME::PALETTE_MAP());
 
         return;
     }

--- a/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.h
+++ b/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.h
@@ -16,7 +16,7 @@
 #include "xdgiconenginecreator.h"
 #endif
 
-namespace DEEPIN_QT_THEME {
+namespace DEEPIN_XDG_THEME {
 enum PaletteType {
     Text,
     Background,
@@ -53,7 +53,7 @@ public:
 
 private:
     XdgIconLoaderEngine *engine;
-    QHash<quint64, DEEPIN_QT_THEME::PALETTE_MAP> entryToColorScheme;
+    QHash<quint64, DEEPIN_XDG_THEME::PALETTE_MAP> entryToColorScheme;
     QIcon::Mode lastMode;
 };
 #endif


### PR DESCRIPTION
file-manager is crashed due to colorScheme variable's naming conflict (xdgiconproxyengine.cpp & qdeepintheme.cpp)

Log: resolve the issue which file-manager is crashed in live-system
Bug: https://pms.uniontech.com/bug-view-188633.html
Influence: icon engine plugin