### PR TITLE
 fix: 使用系统资源图标缩放问题

### DIFF
--- a/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.cpp
+++ b/iconengineplugins/xdgiconproxyengine/xdgiconproxyengine.cpp
@@ -202,16 +202,11 @@ void XdgIconProxyEngine::paint(QPainter *painter, const QRect &rect, QIcon::Mode
         DEEPIN_QT_THEME::colorScheme.setLocalData(mode == QIcon::Selected ? pal.highlightedText().color().name() : pal.windowText().color().name());
     }
 
-    qreal ratio = 1.0;
-    if (qApp->testAttribute(Qt::AA_UseHighDpiPixmaps))
-        ratio = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
-
-    QPixmap pix = pixmap(rect.size() * ratio, mode, state);
+    const QPixmap pix = pixmap(rect.size(), mode, state);
 
     if (pix.isNull())
         return;
 
-    pix.setDevicePixelRatio(ratio);
     painter->drawPixmap(rect, pix);
 }
 


### PR DESCRIPTION
QIcon中有缩放处理，XdgIconProxyEngine多处理了一次缩放

Bug: https://pms.uniontech.com/bug-view-125621.html
Log: 修改屏幕缩放时图标模糊问题