### PR TITLE
fix: Modify PushButton's size to Adapt Compact

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -3865,6 +3865,8 @@ QSize ChameleonStyle::sizeFromContents(QStyle::ContentsType ct, const QStyleOpti
         Q_FALLTHROUGH();
     }
     case CT_PushButton: {
+        // 只将width加上ButtonMargin，对于height的margin通过frame_margins体现
+        size.rheight() -= proxy()->pixelMetric(PM_ButtonMargin, opt, widget);
         int frame_margins = DStyle::pixelMetric(PM_FrameMargins, opt, widget);
         size += QSize(frame_margins * 2, frame_margins * 2);
 


### PR DESCRIPTION
  In design, PushButton's height is 36 in NormalMode
and it is 24 in Compact, the margin of Arrow with frame is 10.
  We only minus `ButtonMargin` for height to adap CompactMode,
and use `ButtonMargin` as Arrow's margin, And `PM_ButtonMinimizedSize` is 36, so we don't worry it is smally.

Issue: https://github.com/linuxdeepin/dtkwidget/issues/326