### PR TITLE
fix: black border in combobox's popup window

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -4154,7 +4154,7 @@ int ChameleonStyle::styleHint(QStyle::StyleHint sh, const QStyleOption *opt,
     case SH_ComboBox_Popup:
         return true;
     case SH_ComboBox_PopupFrameStyle:
-        return true;
+        return QFrame::NoFrame | QFrame::Plain;
     case SH_Slider_AbsoluteSetButtons:
         return Qt::LeftButton | Qt::MidButton;
     case SH_ToolTipLabel_Opacity:


### PR DESCRIPTION
when style is changed, set SH_ComboBox_PopupFrameStyle to the origin frameShape

Log: black border in combobox's popup window
Issue: https://github.com/linuxdeepin/developer-center/issues/3914
Influence: QFrame style