### PR TITLE
fix: DStandardItem hasn't radius

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -256,6 +256,13 @@ void ChameleonStyle::drawPrimitive(QStyle::PrimitiveElement pe, const QStyleOpti
                p->setRenderHint(QPainter::Antialiasing);
                p->drawRoundedRect(select_rect, frame_radius, frame_radius);
                return;
+            } else {
+                if (vopt->backgroundBrush.style() != Qt::NoBrush) {
+                    p->setPen(Qt::NoPen);
+                    p->setRenderHint(QPainter::Antialiasing);
+                    p->drawRoundedRect(opt->rect, frame_radius, frame_radius);
+                    return;
+                }
             }
         }
         break;


### PR DESCRIPTION
  PE_PanelItemViewItem is fill background using backgroundBrash
if backgroundBrush isn't NoBrush, we use drawRounded in this scene.

Issue: https://github.com/linuxdeepin/dtkwidget/issues/399