### PR TITLE
fix: menu window radius not update

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -4230,6 +4230,13 @@ static void updateWeekendTextFormat(QCalendarWidget *calendar, QColor)
     calendar->setWeekdayTextFormat(Qt::Sunday, fmt);
 }
 
+// 最大圆角18, 原来默认是8
+static inline void setWindowRadius(QWidget *w, int radius)
+{
+    DPlatformWindowHandle handle(w);
+    handle.setWindowRadius(radius);
+}
+
 void ChameleonStyle::polish(QWidget *w)
 {
     DStyle::polish(w);
@@ -4251,10 +4258,8 @@ void ChameleonStyle::polish(QWidget *w)
     }
 
     if (auto listview = qobject_cast<QListView *>(w)) {
-        if (listview->parentWidget() == nullptr) {
-            DPlatformWindowHandle handle(listview);
-            handle.setWindowRadius(DStyle::pixelMetric(PM_FrameRadius));
-        }
+        if (listview->parentWidget() == nullptr)
+            setWindowRadius(listview, DStyle::pixelMetric(PM_FrameRadius));
     }
 
     if (w && qobject_cast<QLineEdit *>(w) && !(qobject_cast<DSearchEdit *>(w->parentWidget()))) {
@@ -4263,10 +4268,9 @@ void ChameleonStyle::polish(QWidget *w)
     }
 
     if (auto container = qobject_cast<QComboBoxPrivateContainer *>(w)) {
-        if (DWindowManagerHelper::instance()->hasComposite()) {
-            DPlatformWindowHandle handle(container);
-            handle.setWindowRadius(DStyle::pixelMetric(PM_FrameRadius));
-        }
+        if (DWindowManagerHelper::instance()->hasComposite())
+            setWindowRadius(container, DStyle::pixelMetric(PM_FrameRadius));
+
         if (!DGuiApplicationHelper::isTabletEnvironment())
             container->setFrameStyle(QFrame::NoFrame);
     }
@@ -4274,10 +4278,8 @@ void ChameleonStyle::polish(QWidget *w)
     if (auto calendar = qobject_cast<QCalendarWidget* >(w)) {
         int radius = DStyle::pixelMetric(PM_TopLevelWindowRadius);
         // 只有dtk的应用绘制日历窗口圆角
-        if (dynamic_cast<DApplication *>(QCoreApplication::instance())) {
-            DPlatformWindowHandle handle(calendar);
-            handle.setWindowRadius(radius);
-        }
+        if (dynamic_cast<DApplication *>(QCoreApplication::instance()))
+            setWindowRadius(calendar, radius);
 
         calendar->setVerticalHeaderFormat(QCalendarWidget::NoVerticalHeader);
 
@@ -4342,12 +4344,14 @@ void ChameleonStyle::polish(QWidget *w)
 
             if (DPlatformWindowHandle::isEnabledDXcb(w)) {
                 handle.setEnableBlurWindow(true);
-                // 最大圆角18, 原来默认是8
-                auto theme = DGuiApplicationHelper::instance()->applicationTheme();
-                int wradius = theme->windowRadius();
-                handle.setWindowRadius(qMax(0, qMin(wradius, 18)));
-                w->setAttribute(Qt::WA_TranslucentBackground);
 
+                DPlatformTheme *theme = DGuiApplicationHelper::instance()->applicationTheme();
+                setWindowRadius(w, qMax(0, qMin(theme->windowRadius(), 18)));
+
+                connect(theme, &DPlatformTheme::windowRadiusChanged, w, [w](int r){
+                   setWindowRadius(w, qMax(0, qMin(r, 18)));
+                });
+                w->setAttribute(Qt::WA_TranslucentBackground);
                 connect(DWindowManagerHelper::instance(), SIGNAL(hasCompositeChanged()), w, SLOT(update()));
             }
         } else if (is_tip) {


### PR DESCRIPTION
菜单窗口只是在 polish 时设置了圆角。
主窗口的菜单关闭后并不会销毁，只是隐藏了
如果隐藏后窗口圆角变化并不会跟随

Issue: https://github.com/linuxdeepin/dtkwidget/issues/409