### PR TITLE
chore: use option background brush

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -261,9 +261,12 @@ void ChameleonStyle::drawPrimitive(QStyle::PrimitiveElement pe, const QStyleOpti
                return;
             } else {
                 if (vopt->backgroundBrush.style() != Qt::NoBrush) {
+                    p->save();
                     p->setPen(Qt::NoPen);
+                    p->setBrush(vopt->backgroundBrush);
                     p->setRenderHint(QPainter::Antialiasing);
                     p->drawRoundedRect(opt->rect, frame_radius, frame_radius);
+                    p->restore();
                     return;
                 }
             }


### PR DESCRIPTION
使用 option 中的 brush 而非 QPainter 设置的 brush
防止出现应用设置 QPainter  brush 后污染后续绘制
also FIX https://github.com/linuxdeepin/developer-center/issues/4068