### PR TITLE
fix: edit translucent background

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -301,8 +301,17 @@ void ChameleonStyle::drawPrimitive(QStyle::PrimitiveElement pe, const QStyleOpti
 
         bool isTransBg = false;
         if (w) {
-            isTransBg = w->topLevelWidget()->testAttribute(Qt::WA_TranslucentBackground) ||
-                    w->property("_d_dtk_lineedit_opacity").toBool();
+            auto prop = w->property("_d_dtk_lineedit_opacity");
+
+            if (prop.isValid()) {
+                isTransBg = prop.toBool();
+            } else {
+                const auto windowFlags = w->window()->windowFlags();
+                const bool hasTransAttr = w->window()->testAttribute(Qt::WA_TranslucentBackground);
+                const bool isDialog = windowFlags.testFlag(Qt::Dialog);
+                const bool isPopup = windowFlags.testFlag(Qt::Popup);
+                isTransBg = hasTransAttr && isDialog && !isPopup;
+            }
         }
 
         if (isTransBg)


### PR DESCRIPTION
修复 https://github.com/linuxdeepin/dtk/issues/31 后 edit 在设置过透明的窗口中自带透明背景色
此提交并不能直接修复这个问题.需要应用设置属性
edit->setProperty("_d_dtk_lineedit_opacity", false); // 禁止edit透明背景

Issue: https://github.com/linuxdeepin/developer-center/issues/4069
Bug: https://pms.uniontech.com/bug-view-196961.html