### PR TITLE
fix: event loop doesn't quit normally

### DIFF
--- a/platformthemeplugin/qdeepinfiledialoghelper.h
+++ b/platformthemeplugin/qdeepinfiledialoghelper.h
@@ -8,6 +8,7 @@
 #include <qpa/qplatformdialoghelper.h>
 
 #include <QPointer>
+#include <QEventLoop>
 
 QT_BEGIN_NAMESPACE
 
@@ -49,10 +50,12 @@ private:
     mutable QPointer<QWindow> auxiliaryWindow;
     QPointer<QWindow> activeWindow;
     QPointer<QObject> sourceDialog;
+    QPointer<QEventLoop> execLoop;
     static DFileDialogManager *manager;
 
     void ensureDialog() const;
     void applyOptions();
+    void hideAuxiliaryWindow() const;
 
     friend class QDeepinTheme;
 };


### PR DESCRIPTION
When QFileDialog invokes deleteLater or close, event loop doesn't quit normally because of lacking notification from Qt. Just store local event loop and quit it if running in hide(). Cause hide() will be invoked by Qt when close.

Log: fix event loop doesn't quit normally