### PR TITLE
chore: always use qmake

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 export QT_SELECT = qt5
 
 %:
-	dh $@ 
+	dh $@ --buildsystem=qmake
 
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info


### PR DESCRIPTION
Always use qmake to keep stable when refactor to cmake.