### PR TITLE
feat: imageformatplugins support cmake and Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,3 +85,4 @@ set(PLUGIN_OUTPUT_BASE_DIR ${CMAKE_BINARY_DIR}/plugins CACHE STRING "Plugin outp
 set(PLUGIN_INSTALL_BASE_DIR ${CMAKE_INSTALL_LIBDIR}/qt${QT_VERSION_MAJOR}/plugins CACHE STRING "Plugin install base path")
 
 add_subdirectory(iconengineplugins)
+add_subdirectory(imageformatplugins)

--- a/imageformatplugins/CMakeLists.txt
+++ b/imageformatplugins/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+add_subdirectory(dci)
+add_subdirectory(svg)

--- a/imageformatplugins/dci/CMakeLists.txt
+++ b/imageformatplugins/dci/CMakeLists.txt
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+dtk_add_plugin(
+    NAME
+        dci
+    OUTPUT_DIR
+        ${PLUGIN_OUTPUT_BASE_DIR}/imageformats
+    INSTALL_DIR
+        ${PLUGIN_INSTALL_BASE_DIR}/imageformats
+    SOURCES
+        main.cpp
+        qdciiohandler.cpp
+    HEADERS
+        qdciiohandler.h
+    DEPENDENCIES
+        Dtk${VERSION_SUFFIX}::Gui
+)

--- a/imageformatplugins/svg/CMakeLists.txt
+++ b/imageformatplugins/svg/CMakeLists.txt
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+dtk_add_plugin(
+    NAME
+        svg
+    OUTPUT_DIR
+        ${PLUGIN_OUTPUT_BASE_DIR}/imageformats
+    INSTALL_DIR
+        ${PLUGIN_INSTALL_BASE_DIR}/imageformats
+    SOURCES
+        main.cpp
+        qsvgiohandler.cpp
+    HEADERS
+        qsvgiohandler.h
+    DEPENDENCIES
+        Dtk${VERSION_SUFFIX}::Gui
+)

--- a/imageformatplugins/svg/main.cpp
+++ b/imageformatplugins/svg/main.cpp
@@ -33,10 +33,11 @@ QImageIOPlugin::Capabilities QSvgPlugin::capabilities(QIODevice *device, const Q
 {
     if (format == "svg" || format == "svgz")
         return Capabilities(CanRead);
-    if (!format.isEmpty())
-        return 0;
 
     Capabilities cap;
+    if (!format.isEmpty())
+        return cap;
+
     if (device->isReadable() && QSvgIOHandler::canRead(device))
         cap |= CanRead;
     return cap;


### PR DESCRIPTION
imageformatplugins now support building under Qt6 and using cmake.

Log: imageformatplugins support cmake and Qt6