### PR TITLE
fix: DLineEdit setAlert not work on DDialog

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -323,7 +323,9 @@ void ChameleonStyle::drawPrimitive(QStyle::PrimitiveElement pe, const QStyleOpti
                 const bool hasTransAttr = w->window()->testAttribute(Qt::WA_TranslucentBackground);
                 const bool isDialog = windowFlags.testFlag(Qt::Dialog);
                 const bool isPopup = windowFlags.testFlag(Qt::Popup);
-                isTransBg = hasTransAttr && isDialog && !isPopup;
+                // if we set palette to lineedit (e.g. DLineEdit::setAlert )
+                const bool isResolved = opt->palette.isBrushSet(QPalette::Current, QPalette::Button);
+                isTransBg = hasTransAttr && isDialog && !isPopup && !isResolved;
             }
         }
 


### PR DESCRIPTION
if we set palette to lineedit on dialog(transluent background) use the color we set instead of trans bg color

Issue: https://github.com/linuxdeepin/dtk/issues/91