### PR TITLE
fix: missing 3rdparty sources and resources

### DIFF
--- a/3rdparty/qdbustrayicon.cpp
+++ b/3rdparty/qdbustrayicon.cpp
@@ -60,7 +60,12 @@ static QString generateServiceName()
 {
     const QCoreApplication *app = QCoreApplication::instance();
     const QString domain = app->organizationDomain();
-    const QStringList parts = domain.split(QLatin1Char('.'), QString::SkipEmptyParts);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    auto behavior = Qt::SkipEmptyParts;
+#else
+    auto behavior = QString::SkipEmptyParts;
+#endif
+    const QStringList parts = domain.split(QLatin1Char('.'), behavior);
 
     QString reversedDomain;
     if (parts.isEmpty()) {

--- a/3rdparty/qdbustrayicon_p.h
+++ b/3rdparty/qdbustrayicon_p.h
@@ -18,6 +18,7 @@
 #include "qdbusmenuconnection_p.h"
 #include "qstatusnotifieritemadaptor_p.h"
 #include <private/qtguiglobal_p.h>
+#include <private/qdbusmenubar_p.h>
 
 QT_REQUIRE_CONFIG(systemtrayicon);
 
@@ -27,8 +28,6 @@ QT_REQUIRE_CONFIG(systemtrayicon);
 #include <QLoggingCategory>
 #include <qpa/qplatformsystemtrayicon.h>
 
-class QDBusMenuAdaptor;
-class QDBusPlatformMenu;
 class QXdgNotificationInterface;
 
 namespace thirdparty {

--- a/platformthemeplugin/CMakeLists.txt
+++ b/platformthemeplugin/CMakeLists.txt
@@ -39,13 +39,20 @@ dtk_add_plugin(
         dthemesettings.cpp
         qdeepinfiledialoghelper.cpp
         qdeepintheme.cpp
+        ${CMAKE_SOURCE_DIR}/3rdparty/qdbustrayicon.cpp
+        ${CMAKE_SOURCE_DIR}/3rdparty/qstatusnotifieritemadaptor.cpp
+        ${CMAKE_SOURCE_DIR}/3rdparty/qdbusmenuconnection.cpp
         main.cpp
         ${DBUS_INTERFACES}
     HEADERS
         dthemesettings.h
         qdeepinfiledialoghelper.h
         qdeepintheme.h
+        ${CMAKE_SOURCE_DIR}/3rdparty/qdbustrayicon_p.h
+        ${CMAKE_SOURCE_DIR}/3rdparty/qstatusnotifieritemadaptor_p.h
+        ${CMAKE_SOURCE_DIR}/3rdparty/qdbusmenuconnection_p.h
     RESOURCES
+        icons/deepin-theme-plugin-icons.qrc
         deepin-theme-plugin.qrc
     DEPENDENCIES
         Dtk${VERSION_SUFFIX}::Gui


### PR DESCRIPTION
3rdparty sources are missing thus some symbols cannot be found and libqdeepin.so loading failed. Icon and action resources are also missing. Add them and adapt to Qt6.

Log: fix missing 3rdparty sources and resources