### PR TITLE
fix: do not compile and install dstyleplugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ project(
   LANGUAGES CXX C
 )
 
+option(ENABLE_OLD_STYLE "Enable old style" OFF)
+
 if(PROJECT_VERSION_MAJOR EQUAL 6)
   set(VERSION_SUFFIX 6)
   find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
@@ -69,7 +71,9 @@ function(dtk_add_plugin)
                           PROPERTIES
                           LIBRARY_OUTPUT_DIRECTORY ${TARGET_OUTPUT_DIR})
   endif()
-  install(TARGETS ${TARGET_NAME} DESTINATION ${TARGET_INSTALL_DIR})
+  if(TARGET_INSTALL_DIR)
+    install(TARGETS ${TARGET_NAME} DESTINATION ${TARGET_INSTALL_DIR})
+  endif()
 endfunction()
 
 find_package(Dtk${VERSION_SUFFIX} REQUIRED COMPONENTS Widget)

--- a/styleplugins/CMakeLists.txt
+++ b/styleplugins/CMakeLists.txt
@@ -2,4 +2,6 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 add_subdirectory(chameleon)
-add_subdirectory(dstyleplugin)
+if(ENABLE_OLD_STYLE)
+    add_subdirectory(dstyleplugin)
+endif()

--- a/styleplugins/dstyleplugin/CMakeLists.txt
+++ b/styleplugins/dstyleplugin/CMakeLists.txt
@@ -5,8 +5,6 @@ dtk_add_plugin(
     NAME dstyleplugin
     OUTPUT_DIR
         ${PLUGIN_OUTPUT_BASE_DIR}/styles
-    INSTALL_DIR
-        ${PLUGIN_INSTALL_BASE_DIR}/styles
     SOURCES
         dstyleplugin.cpp
         style.cpp


### PR DESCRIPTION
If ENABLE_OLD_STYLE is not ON manually, dstyleplugin will not be compiled. And it will never be installed even if compiled.

Log: fix do not compile and install dstyleplugin