### PR TITLE
fix: dci icon cache key miss theme name

### DIFF
--- a/iconengineplugins/dciiconengine/dciiconengine.cpp
+++ b/iconengineplugins/dciiconengine/dciiconengine.cpp
@@ -97,7 +97,7 @@ QPixmap DDciIconEngine::pixmap(const QSize &size, QIcon::Mode mode, QIcon::State
     const DDciIcon::Theme theme = dciTheme();
     const DDciIconPalette pa = dciPalettle();
 
-    QString key = QLatin1String("dci_") + m_iconName +
+    QString key = QLatin1String("dci_") + m_iconName + m_iconThemeName +
             DDciIconPalette::convertToString(pa)
             % HexString<uint>(mode)
             % HexString<int>(theme)


### PR DESCRIPTION
dci 图标缓存没有加上主题名导致可能在不同的主题时匹配到其他主题缓存的图标

Issue: https://github.com/linuxdeepin/developer-center/issues/4517