### PR TITLE
fix: The size of the ListView item's rect is incorrect

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -260,8 +260,6 @@ void ChameleonStyle::drawPrimitive(QStyle::PrimitiveElement pe, const QStyleOpti
 
                if (!vopt->showDecorationSelected) {
                    select_rect = proxy()->subElementRect(QStyle::SE_ItemViewItemText,  opt, w);
-               } else {
-                   select_rect -= frameExtentMargins();
                }
 
                p->setPen(Qt::NoPen);


### PR DESCRIPTION
  It introduced in ff4669f1df5bfc61617b9bdb1d67084cb822d7fd,
and remove it depend on UI designer.

Issue: https://github.com/linuxdeepin/dtk/issues/73