### PR TITLE
fix: Combobox's background is wrong when hover

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -2397,6 +2397,8 @@ bool ChameleonStyle::drawComboBox(QPainter *painter, const QStyleOptionComboBox 
                 if (auto lineEdit = combobox->lineEdit()) {
                     if (lineEdit->testAttribute(Qt::WA_SetPalette)) {
                         brush = lineEdit->palette().button();
+                    } else {
+                        brush = getBrush(comboBox, QPalette::Button);
                     }
                 }
             }


### PR DESCRIPTION
  We use button as background when unset brush, and it also takes
effect when hover.

Issue: https://github.com/linuxdeepin/dtk/issues/61