### PR TITLE
fix: dbusmenu related symbols are hidden in Qt6

### DIFF
--- a/platformthemeplugin/CMakeLists.txt
+++ b/platformthemeplugin/CMakeLists.txt
@@ -13,6 +13,16 @@ if(QT_VERSION_MAJOR EQUAL 5)
     else()
         list(APPEND QT_LIBS Qt5::PlatformSupportPrivate) # TODO to be verified
     endif()
+    set(3RD_PARTY_SOURCES
+        ${CMAKE_SOURCE_DIR}/3rdparty/qdbustrayicon.cpp
+        ${CMAKE_SOURCE_DIR}/3rdparty/qstatusnotifieritemadaptor.cpp
+        ${CMAKE_SOURCE_DIR}/3rdparty/qdbusmenuconnection.cpp
+    )
+    set(3RD_PARTY_HEADERS
+        ${CMAKE_SOURCE_DIR}/3rdparty/qdbustrayicon_p.h
+        ${CMAKE_SOURCE_DIR}/3rdparty/qstatusnotifieritemadaptor_p.h
+        ${CMAKE_SOURCE_DIR}/3rdparty/qdbusmenuconnection_p.h
+    )
 else()
     list(APPEND QT_LIBS Qt6::GuiPrivate)
 endif()
@@ -39,18 +49,14 @@ dtk_add_plugin(
         dthemesettings.cpp
         qdeepinfiledialoghelper.cpp
         qdeepintheme.cpp
-        ${CMAKE_SOURCE_DIR}/3rdparty/qdbustrayicon.cpp
-        ${CMAKE_SOURCE_DIR}/3rdparty/qstatusnotifieritemadaptor.cpp
-        ${CMAKE_SOURCE_DIR}/3rdparty/qdbusmenuconnection.cpp
+        ${3RD_PARTY_SOURCES}
         main.cpp
         ${DBUS_INTERFACES}
     HEADERS
         dthemesettings.h
         qdeepinfiledialoghelper.h
         qdeepintheme.h
-        ${CMAKE_SOURCE_DIR}/3rdparty/qdbustrayicon_p.h
-        ${CMAKE_SOURCE_DIR}/3rdparty/qstatusnotifieritemadaptor_p.h
-        ${CMAKE_SOURCE_DIR}/3rdparty/qdbusmenuconnection_p.h
+        ${3RD_PARTY_HEADERS}
     RESOURCES
         icons/deepin-theme-plugin-icons.qrc
         deepin-theme-plugin.qrc

--- a/platformthemeplugin/qdeepintheme.cpp
+++ b/platformthemeplugin/qdeepintheme.cpp
@@ -6,7 +6,9 @@
 #include "qdeepinfiledialoghelper.h"
 #include "filedialogmanager_interface.h"
 #include "dthemesettings.h"
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include "../3rdparty/qdbustrayicon_p.h"
+#endif
 
 #include <DGuiApplicationHelper>
 #include <DPlatformTheme>
@@ -56,6 +58,7 @@ bool QDeepinTheme::m_usePlatformNativeDialog = true;
 QMimeDatabase QDeepinTheme::m_mimeDatabase;
 DThemeSettings *QDeepinTheme::m_settings = 0;
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 static bool isDBusTrayAvailable() {
     static bool dbusTrayAvailable = false;
     static bool dbusTrayAvailableKnown = false;
@@ -68,6 +71,7 @@ static bool isDBusTrayAvailable() {
     }
     return dbusTrayAvailable;
 }
+#endif
 
 static void onIconThemeSetCallback()
 {
@@ -555,7 +559,7 @@ QPixmap QDeepinTheme::fileIconPixmap(const QFileInfo &fileInfo, const QSizeF &si
 }
 #endif
 
-#if !defined(QT_NO_DBUS) && !defined(QT_NO_SYSTEMTRAYICON)
+#if !defined(QT_NO_DBUS) && !defined(QT_NO_SYSTEMTRAYICON) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 QPlatformSystemTrayIcon *QDeepinTheme::createPlatformSystemTrayIcon() const
 {
     if (isDBusTrayAvailable())

--- a/platformthemeplugin/qdeepintheme.h
+++ b/platformthemeplugin/qdeepintheme.h
@@ -31,7 +31,7 @@ public:
                            QPlatformTheme::IconOptions iconOptions = 0) const Q_DECL_OVERRIDE;
 #endif
 
-#if !defined(QT_NO_DBUS) && !defined(QT_NO_SYSTEMTRAYICON)
+#if !defined(QT_NO_DBUS) && !defined(QT_NO_SYSTEMTRAYICON) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QPlatformSystemTrayIcon *createPlatformSystemTrayIcon() const override;
 #endif
 


### PR DESCRIPTION
Dbusmenu related symbols are hidden in Qt6 now, we just can't partially customize it. Either fully override it (Do not depend any symbol in QtGui) or just leave it default. Cause we just make a little customization, just leave it default in Qt6 and try to contribute our improvement to upstream.

Related-Commit: 78fa103aadf39f19b3f613647a7d3931b4b27e57
Log: fix dbusmenu related symbols are hidden in Qt6