### PR TITLE
tests: fix unit tests resource lacking

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -9,7 +9,7 @@ Copyright: None
 License: CC0-1.0
 
 # assets
-Files: styleplugins/dstyleplugin/assets/* 
+Files: styleplugins/dstyleplugin/assets/*
 Copyright: UnionTech Software Technology Co., Ltd.
 License: GPL-3.0-or-later
 
@@ -30,7 +30,7 @@ License: CC0-1.0
 
 # png svg dci
 Files: platformthemeplugin/icons/* styleplugins/chameleon/*.svg styles/images/*.png
-    tests/iconengines/*/icons/*/*.svg tests/iconengines/*/*.svg tests/iconengines/*/icons/*/*.dci 
+    tests/*/icons/*/*.svg tests/*/*.svg tests/*/icons/*/*.dci
     tests/imageformats/dci/*.dci
 Copyright: None
 License: CC0-1.0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(unit-tests
     imageformats/dci/dci_test_files.qrc
     imageformats/svg/ut_qsvgiohandler.cpp
     styleplugins/chameleon/ut_chameleonstyle.cpp
+    styleplugins/chameleon/icons/theme-icons.qrc
     main.cpp
 )
 find_package(GTest REQUIRED)

--- a/tests/styleplugins/chameleon/icons/actions/icon_Layout_16px.svg
+++ b/tests/styleplugins/chameleon/icons/actions/icon_Layout_16px.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>icon_Layout/normal</title>
+    <g id="icon_Layout/normal" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Layout-icon" transform="translate(1.000000, 1.000000)" fill="#626E88">
+            <path d="M6.5,-5.5 L8.5,-5.5 L8.5,-5.5 L8.5,8.5 L6.5,8.5 C5.94771525,8.5 5.5,8.05228475 5.5,7.5 L5.5,-4.5 C5.5,-5.05228475 5.94771525,-5.5 6.5,-5.5 Z" id="矩形备份-4" transform="translate(7.000000, 1.500000) rotate(90.000000) translate(-7.000000, -1.500000) "></path>
+            <polygon id="矩形备份-8" transform="translate(3.500000, 6.000000) rotate(90.000000) translate(-3.500000, -6.000000) " points="1.5 2.5 5.5 2.5 5.5 9.5 1.5 9.5"></polygon>
+            <rect id="矩形" x="0" y="9" width="7" height="2"></rect>
+            <path d="M0,12 L9,12 L9,14 L1,14 C0.44771525,14 6.76353751e-17,13.5522847 0,13 L0,12 L0,12 Z" id="矩形"></path>
+            <path d="M10,12 L14,12 L14,13 C14,13.5522847 13.5522847,14 13,14 L10,14 L10,14 L10,12 Z" id="矩形"></path>
+            <polygon id="矩形备份-8" points="8 4 14 4 14 11 8 11"></polygon>
+        </g>
+    </g>
+</svg>

--- a/tests/styleplugins/chameleon/icons/theme-icons.qrc
+++ b/tests/styleplugins/chameleon/icons/theme-icons.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/icons/deepin/builtin">
+        <file>actions/icon_Layout_16px.svg</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
Styleplugin's unit tests need icon_Layout icon file. This file is provided by builtiniconengine test, now it's removed. Add this resource to styleplugin itself.

Log: fix unit tests resource lacking