### PR TITLE
fix: file manage crash

### DIFF
--- a/iconengineplugins/diconengine/diconengine.json
+++ b/iconengineplugins/diconengine/diconengine.json
@@ -1,3 +1,3 @@
 {
-    "Keys": [ "DIconEngine" ]
+    "Keys": [ "DIconProxyEngine" ]
 }

--- a/iconengineplugins/diconengine/main.cpp
+++ b/iconengineplugins/diconengine/main.cpp
@@ -23,7 +23,7 @@ public:
 
 QStringList DIconEnginePlugin::keys() const
 {
-    return {"DIconEngine"};
+    return {"DIconProxyEngine"};
 }
 
 QIconEngine *DIconEnginePlugin::create(const QString &iconName)

--- a/platformthemeplugin/qdeepintheme.cpp
+++ b/platformthemeplugin/qdeepintheme.cpp
@@ -534,7 +534,7 @@ static QIconEngine *createIconEngineWithKey(const QString &iconName, const QStri
 
 QIconEngine *QDeepinTheme::createIconEngine(const QString &iconName) const
 {
-    QIconEngine *engine = createIconEngineWithKey(iconName, "DIconEngine");
+    QIconEngine *engine = createIconEngineWithKey(iconName, "DIconProxyEngine");
     return engine ? engine : QGenericUnixTheme::createIconEngine(iconName);
 }
 


### PR DESCRIPTION
iconengine's key is inconsistent with the engine's key returned by the interface create

Log: fix the issue that file manage crashes when dragging and dropping the bookmark