### PR TITLE
feat: scrollbar show policy tweak

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.h
+++ b/styleplugins/chameleon/chameleonstyle.h
@@ -93,12 +93,9 @@ public:
 protected:
     void drawMenuItemRedPoint(const QStyleOptionMenuItem *option, QPainter *painter, const QWidget *widget) const;
     void resetAttribute(QWidget *w, bool polish);
-    void transScrollbarMouseEvents(QObject *obj, bool on = true) const;
 
 private:
     mutable QHash<const QObject*, dstyle::DStyleAnimation*> animations;
-
-    bool eventFilter(QObject *watched, QEvent *event) override;
 };
 } // namespace chameleon
 


### PR DESCRIPTION
- 默认显示滚动条，无滚动时启动隐藏动画
- 鼠标掠过滚动条所在（整个）区域，立即显示滚动条，移开启动隐藏动画
- 鼠标悬停，按下滚动条，滚动条一直显示
- 发生滚动时滚动条立即显示

docs:473QyXLRvOSZ7r3w