### PR TITLE
fix: App can't load qml-module-chameleton plugin

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -2826,7 +2826,7 @@ void ChameleonStyle::drawMenuItemBackground(const QStyleOption *option, QPainter
 
         if (shadow_color != option->palette.color(QPalette::Active, QPalette::Highlight)) {
             shadow_color = option->palette.color(QPalette::Active, QPalette::Highlight);
-            QImage image(":/chameleon/menu_shadow.svg");
+            QImage image(":/chameleonstyle/menu_shadow.svg");
             QPainter pa(&image);
             pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
             pa.fillRect(image.rect(), shadow_color);

--- a/styleplugins/chameleon/resources.qrc
+++ b/styleplugins/chameleon/resources.qrc
@@ -1,5 +1,5 @@
 <RCC>
-    <qresource prefix="/chameleon">
+    <qresource prefix="/chameleonstyle">
         <file>menu_shadow.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
  This issue will occur when the application uses QApplication instead of
QGuiApplication in deepin desktop environment.
  `libqdeepin.so` cause `libchameleon.so` will be loaded because
QDeepinTheme::themeHint point `chameleon` style, and chameleon plugin
use `chameleon` resource prefix.
QQuickStyleSpec::findStyle in qquickstyle.cpp will find style in
resource path because of `QDir::entryList`, and it causes `style`
is changed to `:/chameleon`, so Chameleon can't be loaded.
  Control's style will fallback to Basic style.

Log: chameleon含有`/chameleon`前缀的资源，导致qml对应的Chameleon加载失败
Issue: https://github.com/linuxdeepin/dtk/issues/11
