### PR TITLE
fix: remove unused dropped header

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -9,7 +9,6 @@
 #include <DStyleOption>
 #include <DApplication>
 #include <DPlatformWindowHandle>
-#include <DApplicationHelper>
 #include <DWindowManagerHelper>
 #include <DPlatformTheme>
 #include <DSlider>


### PR DESCRIPTION
DApplicationHelper is totally dropped in dtk6. Just remove this header inclusion cause it's not used.

Log: remove unused dropped header