### PR TITLE
fix: svg/dci pixmap not clear when DPR > 1

### DIFF
--- a/imageformatplugins/dci/qdciiohandler.cpp
+++ b/imageformatplugins/dci/qdciiohandler.cpp
@@ -11,6 +11,7 @@
 #include "qvariant.h"
 #include "qbuffer.h"
 #include "qdebug.h"
+#include <QGuiApplication>
 
 #include <DDciIcon>
 
@@ -95,7 +96,6 @@ QDciIOHandler::QDciIOHandler()
 
 }
 
-
 QDciIOHandler::~QDciIOHandler()
 {
     delete d;
@@ -120,6 +120,17 @@ QByteArray QDciIOHandler::name() const
     return "dci";
 }
 
+static inline qreal devicePixelRatio()
+{
+    qreal ratio = 1.0;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    if (qApp->testAttribute(Qt::AA_UseHighDpiPixmaps))
+#endif
+        ratio = qApp->devicePixelRatio();
+
+    return ratio;
+}
+
 bool QDciIOHandler::read(QImage *image)
 {
     if (d->readDone || d->load(device())) {
@@ -128,7 +139,7 @@ bool QDciIOHandler::read(QImage *image)
 
         if (finalSize > 0) {
             DDciIconPalette palette(QColor::Invalid, d->backColor);
-            *image = d->icon.pixmap(1.0, finalSize, d->current, palette).toImage();
+            *image = d->icon.pixmap(devicePixelRatio(), finalSize, d->current, palette).toImage();
         }
         d->readDone = true;
         return true;


### PR DESCRIPTION
QSvgIOHandler multiply final size by device pixel ratio and setDevicePixelRatio to make pixmap clear

```cpp
QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
QLabel label;
// /usr/share/dsg/icons/flow/3depict.dci
label.setPixmap(QPixmap("/usr/share/icons/bloom/apps/32/preferences-system.svg"));
label.show();
```
```sh
D_DXCB_DISABLE_OVERRIDE_HIDPI=1 QT_SCALE_FACTOR=1.25 ./test_pix
-platformpath /path/to/qt5integratoin-plugins-path
```