### PR TITLE
Revert "fix: qapitrace open file crash"

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -208,8 +208,9 @@ void ChameleonStyle::drawPrimitive(QStyle::PrimitiveElement pe, const QStyleOpti
 
         //QTreeView的绘制复制了QCommonStyle的代码，添加了圆角的处理,hover的处理
         if (qobject_cast<const QTreeView *>(w)) {
+            const auto &delegate = *qobject_cast<const QTreeView *>(w)->itemDelegate();
             //如果QTreeView使用的不是默认代理 QStyledItemDelegate,则采取DStyle的默认绘制(备注:这里的QtCreator不会有hover效果和圆角)
-            if (!qobject_cast<QStyledItemDelegate *>(qobject_cast<const QTreeView *>(w)->itemDelegate())) {
+            if (typeid(delegate) != typeid(QStyledItemDelegate)) {
                 break;
             }
 
@@ -575,8 +576,9 @@ void ChameleonStyle::drawPrimitive(QStyle::PrimitiveElement pe, const QStyleOpti
         }
         //这里QTreeView的绘制复制了QCommonStyle的代码，添加了圆角的处理,hover的处理
         if (qobject_cast<const QTreeView *>(w)) {
+            const auto &delegate = *qobject_cast<const QTreeView *>(w)->itemDelegate();
             //如果QTreeView使用的不是默认代理 QStyledItemDelegate,则采取DStyle的默认绘制(备注:这里的QtCreator不会有hover效果和圆角)
-            if (!qobject_cast<QStyledItemDelegate *>(qobject_cast<const QTreeView *>(w)->itemDelegate())) {
+            if (typeid(delegate) != typeid(QStyledItemDelegate)) {
                 break;
             }
 


### PR DESCRIPTION
This reverts commit b80e65a4f15d3b505324c0daf2acde6a76efceb6. treeview select state paint error (e.g. deepin-system-monitor, deepin-devicemanager)