### PR TITLE
fix: icon size of the selected item in context menu

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -2954,8 +2954,8 @@ bool ChameleonStyle::drawMenuItem(const QStyleOptionMenuItem *option, QPainter *
 
             if (checkable) {
                 checkRect.setLeft(frameRadius);
-                checkRect.setWidth(smallIconSize);
-                checkRect.setHeight(smallIconSize);
+                checkRect.setWidth(smallIconSize - 2);
+                checkRect.setHeight(smallIconSize - 4);
                 checkRect.moveCenter(QPoint(checkRect.left() + smallIconSize / 2, menuItem->rect.center().y()));
                 painter->setRenderHint(QPainter::Antialiasing);
 


### PR DESCRIPTION
change the icon size of the selected item in the menu according to the suggestion from the designer

Issue: https://github.com/linuxdeepin/developer-center/issues/7446