### PR TITLE
fix: try to activate dialog service before init manager

### DIFF
--- a/platformthemeplugin/qdeepinfiledialoghelper.cpp
+++ b/platformthemeplugin/qdeepinfiledialoghelper.cpp
@@ -360,9 +360,18 @@ void QDeepinFileDialogHelper::initDBusFileDialogManager()
     } else {
         dialogService = DIALOG_SERVICE;
     }
+
+    const auto *managerObjectPath = "/com/deepin/filemanager/filedialogmanager";
+    auto conn = QDBusConnection::sessionBus();
+    auto reply = conn.call(QDBusMessage::createMethodCall(dialogService, managerObjectPath , "org.freedesktop.DBus.Peer", "Ping"));
+
+    if(reply.type() != QDBusMessage::ReplyMessage) {
+        qCWarning(fileDialogHelper) << reply.errorMessage();
+    }
+
     if (QDBusConnection::sessionBus().interface()->isServiceRegistered(dialogService).value()
         || !QStandardPaths::findExecutable("dde-desktop").isEmpty()) {
-        manager = new DFileDialogManager(dialogService, "/com/deepin/filemanager/filedialogmanager", QDBusConnection::sessionBus());
+        manager = new DFileDialogManager(dialogService, managerObjectPath, QDBusConnection::sessionBus());
     }
 }
 


### PR DESCRIPTION
In linglong container, application couldn't find binary `dde-desktop`,
and `com.deepin.filemanager.filedialog` may not be activated.
So we use the `D-Bus Activation` mechanism to activate this service.

Issue: https://github.com/linuxdeepin/developer-center/issues/8433