### PR TITLE
fix: improve SVG icon cache validation

### DIFF
--- a/iconengineplugins/svgiconengine/qsvgiconengine.cpp
+++ b/iconengineplugins/svgiconengine/qsvgiconengine.cpp
@@ -175,7 +175,9 @@ QPixmap QSvgIconEngine::pixmap(const QSize &size, QIcon::Mode mode,
 
     QString cacheFile;
 
-    if (Q_LIKELY(!svgFile.startsWith(":/") && QFile::exists(svgFile))) {
+    const QFileInfo svgFileInfo(svgFile);
+    // ostree管理的源文件 lastModified 被重置为1970-01-01，qt认为是无效时间，无法设置到缓存文件中
+    if (Q_LIKELY(!svgFile.startsWith(":/") && svgFileInfo.exists() && svgFileInfo.lastModified().isValid())) {
         static const QString &cachePath = getIconCachePath();
 
         if (Q_LIKELY(!cachePath.isEmpty())) {
@@ -192,8 +194,6 @@ QPixmap QSvgIconEngine::pixmap(const QSize &size, QIcon::Mode mode,
 
     const QFileInfo cacheFileInfo(cacheFile);
     if (Q_LIKELY(cacheFileInfo.exists())) {
-        const QFileInfo svgFileInfo(svgFile);
-
         if (Q_UNLIKELY(svgFileInfo.lastModified() != cacheFileInfo.lastModified())) {
             // clear invalid cache file
             QFile::remove(cacheFile);


### PR DESCRIPTION
1. Added QFileInfo check for SVG file existence and lastModified
validity before cache processing
2. Moved svgFileInfo creation outside conditional block for reuse
3. Ensures cache invalidation properly checks file modification times
4. Prevents potential cache issues with invalid file timestamps

fix: 改进SVG图标缓存验证

1. 在缓存处理前添加对SVG文件存在性和最后修改时间的QFileInfo检查
2. 将svgFileInfo创建移到条件块外以便重用
3. 确保缓存失效时正确检查文件修改时间
4. 防止因无效文件时间戳导致的潜在缓存问题
