### PR TITLE
chore: update workflow and package version

### DIFF
--- a/.github/workflows/call-auto-release.yml
+++ b/.github/workflows/call-auto-release.yml
@@ -5,7 +5,7 @@ on:
       version:
         description: 'Release version (e.g., 1.0.0)'
         type: string
-        required: true
+        required: false
       name:
         description: 'The name of the person to release the version'
         type: string

--- a/rpm/deepin-qt5integration.spec
+++ b/rpm/deepin-qt5integration.spec
@@ -1,7 +1,7 @@
 %global repo qt5integration
 
 Name:           deepin-qt5integration
-Version:        5.1.5
+Version:        5.7.17
 Release:        1%{?dist}
 Summary:        Qt platform theme integration plugins for DDE
 # The entire source code is GPLv3+ except styles/ which is BSD,


### PR DESCRIPTION
1. Changed version parameter from required to optional in GitHub
workflow to make releases more flexible
2. Updated package version from 5.1.5 to 5.7.17 in RPM spec file to
reflect current development state
3. These changes prepare the system for more flexible release management
and version tracking

chore: 更新工作流和软件包版本

1. 将 GitHub 工作流中的版本参数从必填改为可选，使发布更加灵活
2. 将 RPM 规范文件中的软件包版本从 5.1.5 更新到 5.7.17，以反映当前开发
状态
3. 这些变更为更灵活的发布管理和版本跟踪做准备
