### PR TITLE
fix: add security hardening flags to build process

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,11 @@
 #!/usr/bin/make -f
 
+# 安全编译参数
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
+
 %:
 	dh $@
 


### PR DESCRIPTION
1. Added security hardening compiler and linker flags to debian/rules
2. Enabled stack protection, RELRO, immediate binding, and NX
protections
3. These changes improve binary security against common exploit
techniques
4. Follows Debian hardening best practices for package builds

fix: 在构建过程中添加安全加固标志

1. 在 debian/rules 中添加了安全加固的编译器和链接器标志
2. 启用了栈保护、RELRO、立即绑定和NX保护
3. 这些更改提高了二进制文件对常见漏洞利用技术的防护能力
4. 遵循 Debian 软件包构建的安全加固最佳实践
