### PR TITLE
fix: remove maybe_unused attribute and add Q_UNUSED

### DIFF
--- a/iconengineplugins/svgiconengine/qsvgiconengine.cpp
+++ b/iconengineplugins/svgiconengine/qsvgiconengine.cpp
@@ -232,7 +232,7 @@ QPixmap QSvgIconEngine::pixmap(const QSize &size, QIcon::Mode mode,
         const QImage image = renderer.toImage(actualSize);
 
         if (Q_LIKELY(!image.isNull() && !cacheFile.isEmpty())) {
-            [[ maybe_unused ]] auto result = QtConcurrent::run(QThreadPool::globalInstance(), [image, cacheFile, svgFile] {
+            auto result = QtConcurrent::run(QThreadPool::globalInstance(), [image, cacheFile, svgFile] {
                 QSaveFile file(cacheFile);
                 // 增加cache文件能被成功保存的概率
                 file.setDirectWriteFallback(true);
@@ -254,6 +254,7 @@ QPixmap QSvgIconEngine::pixmap(const QSize &size, QIcon::Mode mode,
                                         << ", cache file:" << cacheFile << ", svg file:" << svgFile;
                 }
             });
+            Q_UNUSED(result)
         }
 
         // 缩放图标到目标大小


### PR DESCRIPTION
Removed the [[maybe_unused]] attribute from the QtConcurrent::run result
variable and replaced it with Q_UNUSED macro. This change was made
because:
1. [[maybe_unused]] is a C++17 feature that might not be supported in
all build environments
2. Q_UNUSED is the Qt-specific and more portable way to suppress unused
variable warnings
3. Maintains consistency with Qt coding standards
4. The variable is intentionally unused as we're running the task
asynchronously without tracking the result

fix: 移除 maybe_unused 属性并添加 Q_UNUSED

移除了 QtConcurrent::run 结果变量的 [[maybe_unused]] 属性，改用 Q_UNUSED
宏。此变更的原因是：
1. [[maybe_unused]] 是 C++17 特性，可能在某些构建环境中不受支持
2. Q_UNUSED 是 Qt 特有的更便携的方式来抑制未使用变量警告
3. 保持与 Qt 编码标准的一致性
4. 该变量是故意不使用的，因为我们异步运行任务而不跟踪结果
