### PR TITLE
fix: FTBFS with Qt 6.9.2

### DIFF
--- a/platformthemeplugin/qdeepintheme.cpp
+++ b/platformthemeplugin/qdeepintheme.cpp
@@ -158,7 +158,11 @@ static void updateWindowGeometry(QWindow *w)
         return;
 
     if (w->property(DNOT_UPDATE_WINDOW_GEOMETRY).toBool()) {
-        QWindowSystemInterfacePrivate::GeometryChangeEvent gce(w, QHighDpi::fromNativePixels(w->handle()->geometry(), w)
+        QWindowSystemInterfacePrivate::GeometryChangeEvent gce(w
+                                                   #if QT_VERSION >= QT_VERSION_CHECK(6, 9, 2)
+                                                               , QHighDpi::fromNativeWindowGeometry(w->handle()->geometry(), w)
+                                                   #endif
+                                                               , QHighDpi::fromNativePixels(w->handle()->geometry(), w)
                                                    #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
                                                                , QRect()
                                                    #endif


### PR DESCRIPTION
确保 Qt 6.9.2 可构建. 相关 Qt 变动:

https://github.com/qt/qtbase/commit/a676ac0ee587014ddbe79a3b986b39909c4004f2
