### PR TITLE
fix: use platform check API for menu decoration in treeland

### DIFF
--- a/styleplugins/chameleon/chameleonstyle.cpp
+++ b/styleplugins/chameleon/chameleonstyle.cpp
@@ -18,7 +18,7 @@
 #include <DDciIcon>
 #include <DDciIconPalette>
 #include <DSizeMode>
-#include <dtkgui_config.h>
+#include <DGuiApplicationHelper>
 
 #include <QLabel>
 #include <QCalendarWidget>
@@ -4755,7 +4755,7 @@ void ChameleonStyle::polish(QWidget *w)
         view->setItemDelegate(new QStyledItemDelegate);
     }
 
-    if (DApplication::isDXcbPlatform() || (qApp->platformName() == "dwayland" || qApp->property("_d_isDwayland").toBool())) {
+    if (DApplication::isDXcbPlatform() || DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
         bool is_menu = qobject_cast<QMenu *>(w);
         bool is_tip = w->inherits("QTipLabel");
 


### PR DESCRIPTION
1. Replace manual platform name checking with DTK API to detect Wayland
platform
2. Fix menu decoration issue under treeland by using proper platform
detection method
3. Include DGuiApplicationHelper header for the new API usage

Log: Fixed menu decoration issue in treeland environment by using
correct platform detection API

Influence:
1. Test menu display in treeland environment
2. Verify menu decorations appear correctly
3. Test menu functionality in other window managers (dxcb, dwayland)
4. Verify no regression in normal X11 environment
5. Test context menus in various applications

fix: 适配treeland下菜单无装饰器问题

1. 使用DTK API替换手动平台名称检查来检测Wayland平台
2. 通过正确的平台检测方法修复treeland下的菜单装饰问题
3. 添加DGuiApplicationHelper头文件以使用新的API

Log: 修复treeland环境下菜单没有装饰器的问题

Influence:
1. 在treeland环境测试菜单显示
2. 验证菜单装饰器是否正确显示
3. 在其他窗口管理器（dxcb、dwayland）测试菜单功能
4. 验证在普通X11环境下没有回归问题
5. 测试各种应用程序中的上下文菜单

## Summary by Sourcery

Use DTK's platform helper to detect Wayland and fix menu decoration behavior on treeland.

Bug Fixes:
- Resolve missing menu decorations on treeland by using proper Wayland platform detection.

Enhancements:
- Replace manual platform name and property checks with DGuiApplicationHelper-based Wayland detection for menu styling logic.