### PR TITLE
feat: support QStyleHints::colorScheme() to get light/dark theme

### DIFF
--- a/platformthemeplugin/qdeepintheme.cpp
+++ b/platformthemeplugin/qdeepintheme.cpp
@@ -669,6 +669,24 @@ const QPalette *QDeepinTheme::palette(QPlatformTheme::Palette type) const
     return &palette;
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+Qt::ColorScheme QDeepinTheme::colorScheme() const
+{
+    auto *helper = DGuiApplicationHelper::instance();
+    if (!helper)
+        return QGenericUnixTheme::colorScheme();
+
+    switch (helper->themeType()) {
+    case DGuiApplicationHelper::DarkType:
+        return Qt::ColorScheme::Dark;
+    case DGuiApplicationHelper::LightType:
+        return Qt::ColorScheme::Light;
+    default:
+        return Qt::ColorScheme::Unknown;
+    }
+}
+#endif
+
 static QFont *createUnresolveFont(const QString &family, qreal pointSize)
 {
     auto font = new QFont(family);

--- a/platformthemeplugin/qdeepintheme.h
+++ b/platformthemeplugin/qdeepintheme.h
@@ -41,6 +41,9 @@ public:
 
     QVariant themeHint(ThemeHint hint) const Q_DECL_OVERRIDE;
     const QPalette *palette(Palette type) const override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    Qt::ColorScheme colorScheme() const override;
+#endif
     const QFont *font(Font type) const Q_DECL_OVERRIDE;
     DThemeSettings *settings() const;
     static DThemeSettings *getSettings();


### PR DESCRIPTION
Previously we don't support such feature, thus applications rely on this API to check system light/dark theme won't work. This make such API work.

Log:

验证方式：

```qml
import QtQuick

Rectangle {
    // Check if the current theme is Dark
    property bool isDarkMode: Application.styleHints.colorScheme === Qt.ColorScheme.Dark
    color: isDarkMode ? "dark" : "white"
    
    Component.onCompleted: {
        if (isDarkMode) {
            console.log("Current theme is DARK")
        } else {
            console.log("Current theme is LIGHT")
        }
    }
}
```

PMS: 369921