### PR TITLE
feat: support setColorScheme() API as well

### DIFF
--- a/platformthemeplugin/qdeepintheme.cpp
+++ b/platformthemeplugin/qdeepintheme.cpp
@@ -672,19 +672,67 @@ const QPalette *QDeepinTheme::palette(QPlatformTheme::Palette type) const
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 Qt::ColorScheme QDeepinTheme::colorScheme() const
 {
+    if (m_requestedColorScheme != Qt::ColorScheme::Unknown)
+        return m_requestedColorScheme;
+
     auto *helper = DGuiApplicationHelper::instance();
     if (!helper)
         return QGenericUnixTheme::colorScheme();
 
-    switch (helper->themeType()) {
-    case DGuiApplicationHelper::DarkType:
-        return Qt::ColorScheme::Dark;
-    case DGuiApplicationHelper::LightType:
-        return Qt::ColorScheme::Light;
-    default:
-        return Qt::ColorScheme::Unknown;
+    // Check DTK's explicit palette type first. This value may be set by
+    // setPaletteType() or restored from DConfig persistence across sessions.
+    if (helper->paletteType() != DGuiApplicationHelper::UnknownType) {
+        switch (helper->paletteType()) {
+        case DGuiApplicationHelper::DarkType:
+            return Qt::ColorScheme::Dark;
+        case DGuiApplicationHelper::LightType:
+            return Qt::ColorScheme::Light;
+        default:
+            break;
+        }
+    }
+
+    // Fall back to DPlatformTheme::themeName() for system theme detection,
+    // consistent with DTK's fetchPalette(). Don't use themeType() here
+    // because it falls back to palette luminance via toColorType(), and
+    // during QGuiApplicationPrivate::handleThemeChanged() the palette
+    // hasn't been updated yet when colorScheme() is called.
+    DPlatformTheme *theme = helper->applicationTheme();
+    if (theme) {
+        const QByteArray themeName = theme->themeName();
+        if (themeName.endsWith("dark"))
+            return Qt::ColorScheme::Dark;
+    }
+
+    return Qt::ColorScheme::Light;
+}
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+void QDeepinTheme::requestColorScheme(Qt::ColorScheme scheme)
+{
+    // Don't skip Unknown requests: they need to reset the DTK palette type
+    // even when m_requestedColorScheme is already Unknown (e.g. DConfig
+    // persisted a non-Unknown palette type from a previous session).
+    if (m_requestedColorScheme == scheme && scheme != Qt::ColorScheme::Unknown)
+        return;
+    m_requestedColorScheme = scheme;
+    QPlatformTheme::requestColorScheme(scheme);
+
+    if (auto *helper = DGuiApplicationHelper::instance()) {
+        switch (scheme) {
+        case Qt::ColorScheme::Dark:
+            helper->setPaletteType(DGuiApplicationHelper::DarkType);
+            break;
+        case Qt::ColorScheme::Light:
+            helper->setPaletteType(DGuiApplicationHelper::LightType);
+            break;
+        case Qt::ColorScheme::Unknown:
+            helper->setPaletteType(DGuiApplicationHelper::UnknownType);
+            break;
+        }
     }
 }
+#endif
 #endif
 
 static QFont *createUnresolveFont(const QString &family, qreal pointSize)

--- a/platformthemeplugin/qdeepintheme.h
+++ b/platformthemeplugin/qdeepintheme.h
@@ -44,6 +44,9 @@ public:
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     Qt::ColorScheme colorScheme() const override;
 #endif
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    void requestColorScheme(Qt::ColorScheme scheme) override;
+#endif
     const QFont *font(Font type) const Q_DECL_OVERRIDE;
     DThemeSettings *settings() const;
     static DThemeSettings *getSettings();
@@ -54,6 +57,9 @@ private:
     static bool m_usePlatformNativeDialog;
     static QMimeDatabase m_mimeDatabase;
     static DThemeSettings *m_settings;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    Qt::ColorScheme m_requestedColorScheme = Qt::ColorScheme::Unknown;
+#endif
 
     friend class QDeepinFileDialogHelper;
     friend class QDeepinPlatformMenu;


### PR DESCRIPTION
支持 Qt 6.8 的 QStyleHints::setColorScheme() 以及对应的
resetColorScheme() 接口

This amends: ba6d77f

PMS: BUG-369921

可供测试的 QML 程序：

```qml
import QtQuick
import QtQuick.Controls

Rectangle {
    id: root
    property bool isDarkMode: Application.styleHints.colorScheme === Qt.ColorScheme.Dark
    color: isDarkMode ? "#333" : "white"

    Column {
        anchors.centerIn: parent
        spacing: 16

        Text {
            anchors.horizontalCenter: parent.horizontalCenter
            font.pixelSize: 20
            color: root.isDarkMode ? "white" : "black"
            text: "ColorScheme: " + Application.styleHints.colorScheme
        }

        Row {
            anchors.horizontalCenter: parent.horizontalCenter
            spacing: 12

            Button {
                text: "Set Dark"
                onClicked: Application.styleHints.colorScheme = Qt.ColorScheme.Dark
            }

            Button {
                text: "Set Light"
                onClicked: Application.styleHints.colorScheme = Qt.ColorScheme.Light
            }

            Button {
                text: "Reset"
                onClicked: Application.styleHints.colorScheme = Qt.ColorScheme.Unknown
            }
        }

        Text {
            anchors.horizontalCenter: parent.horizontalCenter
            font.pixelSize: 14
            color: root.isDarkMode ? "#aaa" : "#666"
            text: "colorSchemeChanged signal updates this display"
        }
    }

    Connections {
        target: Application.styleHints
        function onColorSchemeChanged(scheme) {
            console.log("colorSchemeChanged:", scheme)
            root.isDarkMode = (scheme === Qt.ColorScheme.Dark)
        }
    }
}
```

## Summary by Sourcery

Support Qt 6.8 color scheme requests in the Deepin platform theme and align color scheme resolution with DTK’s palette and system theme semantics.

New Features:
- Implement requestColorScheme() to propagate Qt color scheme requests to DTK and trigger theme updates.

Enhancements:
- Refine colorScheme() to honor explicitly configured DTK palette types and system theme names before falling back to a default scheme.
- Track the last requested color scheme within QDeepinTheme to coordinate Qt and DTK behavior across sessions.